### PR TITLE
Fix #77: Remove AttributesList class and use list[Attribute] directly

### DIFF
--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -185,20 +185,6 @@ class Attribute(BaseModel):
                 continue
 
 
-class AttributesList(BaseModel):
-    """Container for a list of attributes."""
-
-    attributes: list[Attribute]
-
-    def __iter__(self):  # noqa: ANN204
-        """Make AttributesList iterable over its attributes."""
-        yield from self.attributes
-
-    def to_list(self) -> list[Attribute]:
-        """Convert to a simple list of attributes."""
-        return list(self)
-
-
 class Document(BaseModel):
     """Represents a document in the dataset."""
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -11,7 +11,6 @@ from destiny_sdk.references import Reference
 from deet.data_models.base import (
     AnnotationType,
     Attribute,
-    AttributesList,
     AttributeType,
     Document,
     GoldStandardAnnotatedDocument,
@@ -112,48 +111,6 @@ def test_attribute_validation_required_fields() -> None:
     assert attr.question_target == "Test"
     assert attr.attribute_id == 12345
     assert attr.attribute_label == "Test Label"
-
-
-def test_attributes_list_creation() -> None:
-    """Test creating AttributesList with multiple attributes."""
-    attrs = [
-        Attribute(
-            question_target="Question 1",
-            output_data_type=AttributeType.BOOL,
-            attribute_id=1234,
-            attribute_label="Attribute 1",
-        ),
-        Attribute(
-            question_target="Question 2",
-            output_data_type=AttributeType.STRING,
-            attribute_id=2345,
-            attribute_label="Attribute 2",
-        ),
-    ]
-    attr_list = AttributesList(attributes=attrs)
-    assert len(attr_list.attributes) == 2
-    assert attr_list.attributes[0].attribute_id == 1234
-    assert attr_list.attributes[1].attribute_id == 2345
-
-
-def test_attributes_list_iteration() -> None:
-    """Test that AttributesList is iterable."""
-    attrs = [
-        Attribute(
-            question_target="Question 1",
-            output_data_type=AttributeType.BOOL,
-            attribute_id=1234,
-            attribute_label="Attribute 1",
-        ),
-    ]
-    attr_list = AttributesList(attributes=attrs)
-
-    # Test iteration
-    for attr in attr_list:
-        assert attr.attribute_id == 1234
-
-    # Test to_list method
-    assert attr_list.to_list() == attrs
 
 
 def test_write_to_csv_creates_new_file(tmp_path) -> None:


### PR DESCRIPTION
## Description

This PR fixes #77 by removing the `AttributesList` class and refactoring the codebase to use `list[Attribute]` and `list[EppiAttribute]` directly throughout.

## Changes

- ✅ Removed `AttributesList` class from `deet/data_models/base.py`
- ✅ Removed `AttributesList` tests from `tests/unit/test_base.py`
- ✅ Removed `AttributesList` import from test file
- ✅ Verified annotation converter already uses `list[EppiAttribute]` directly (no changes needed)

## Rationale

The codebase was already interfacing with these types using `list[Attribute]` throughout, making the wrapper class unnecessary. This simplifies the codebase and removes an unused abstraction layer.

## Testing

- All existing tests pass
- No linting errors introduced
- Annotation converter continues to work as expected