### PR TITLE
Fix linting issues arising from `bug-report.md`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,26 +1,29 @@
 ---
 name: Bug report issue template
-about: Issues which specifically relate to bugs in `deet`. 
+about: Issues which specifically relate to bugs in `deet`.
 title: ''
 labels: ''
 assignees: ''
 
 ---
-# Describe the bug
+## Describe the bug
+
 A clear and concise description of what the bug is.
 
-# To Reproduce
+## To Reproduce
+
 Either paste relevant files/data/commands here, ideally wrapping them in a \``` \``` block, OR, reference/describe files you have attached to the issue.
 Include everything that doesn't come with the repo out of the box.
 
-# Expected behavior
+## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-# Screenshots/Video
+## Screenshots/Video
 
 If applicable, add screenshots/video to help explain your problem. Remember to mark the area in the application thats impacted.
 
-# System setup/context
+## System setup/context
 
 - OS: [e.g. Windows 10.11.6]
 - branch name [e.g. `main`]
@@ -28,4 +31,4 @@ If applicable, add screenshots/video to help explain your problem. Remember to m
 - uv version
 - [anything else you feel might be relevant, perhaps relating to LLM config]
 
-# Add any other context about the problem here.
+## Add any other context about the problem here


### PR DESCRIPTION
- Linting fixes
- multiple top-level headings found, which stopped the pre-commit markdownlint fix
- top-level headings swapped for `h2`/`##` equivalent