### PR TITLE
Revert "refactor: Remove PDF-to-title mapping and use nested reference struct…"

### DIFF
--- a/deet/processors/eppi_annotation_converter.py
+++ b/deet/processors/eppi_annotation_converter.py
@@ -215,19 +215,16 @@ class EppiAnnotationConverter:
             text_details
         )
 
-        output_data: str | bool | int | float | list | dict = (
-            " | ".join(extracted_texts) if extracted_texts else ""
-        )
+        output_data: str | bool = " | ".join(extracted_texts) if extracted_texts else ""
 
-        # Coerce output_data to match attribute's output_data_type. Required because
-        # EppiGoldStandardAnnotation validates type. When ItemAttributeFullTextDetails
-        # is absent, use type-appropriate defaults. For BOOL with text, use truthiness.
+        # Coerce empty string to False for BOOL attributes (backward compatibility
+        # when ItemAttributeFullTextDetails is absent)
+        # NOTE @sagaruprety this (modified to coerce all bools to bool) is OK
+        # for eppi as we're only expecting bool/str, but we need to implement
+        # elsewhere a functionality that auto-maps output_data to the correct data type.
         attr = attributes_lookup.get(annotation.get("AttributeId", 0))
-        if attr is not None:
-            if not extracted_texts:
-                output_data = attr.output_data_type.to_python_type()()
-            elif attr.output_data_type == AttributeType.BOOL:
-                output_data = bool(output_data)
+        if attr is not None and attr.output_data_type == AttributeType.BOOL:
+            output_data = bool(output_data)
 
         # Look up the attribute from the attributes list
         if (attribute_id := annotation.get("AttributeId")) is None:
@@ -287,10 +284,53 @@ class EppiAnnotationConverter:
             for annotation in annotations_data
         ]
 
+    def _create_pdf_to_title_mapping(
+        self, references: list[dict[str, Any]]
+    ) -> dict[str, str]:
+        """Create mapping from PDF filenames to document titles."""
+        pdf_to_title_mapping = {}
+        for ref in references:
+            title = ref.get("Title", "")
+            pdf_filename = title.replace(" ", "_") + ".pdf"
+            pdf_to_title_mapping[pdf_filename] = title
+
+            year = ref.get("Year", "")
+            if year:
+                authors = (
+                    ref.get("Authors", "").split(";")[0].strip()
+                    if ref.get("Authors")
+                    else ""
+                )
+                if authors:
+                    author_year_pdf = f"{authors.split()[0]} {year}.pdf"
+                    pdf_to_title_mapping[author_year_pdf] = title
+
+        return pdf_to_title_mapping
+
+    def _find_document_annotations(
+        self,
+        all_annotations_raw: list[dict[str, Any]],
+        doc_title: str,
+        pdf_to_title_mapping: dict[str, str],
+    ) -> list[dict[str, Any]]:
+        """Find annotations for a specific document."""
+        doc_annotations = []
+        for ann in all_annotations_raw:
+            for text_detail in ann.get("ItemAttributeFullTextDetails", []):
+                doc_title_from_ann = text_detail.get("DocTitle", "")
+                if doc_title_from_ann == doc_title or (
+                    doc_title_from_ann in pdf_to_title_mapping
+                    and pdf_to_title_mapping[doc_title_from_ann] == doc_title
+                ):
+                    doc_annotations.append(ann)
+                    break
+
+        return doc_annotations
+
     def process_annotation_file(
         self,
         file_path: str | Path,
-        set_attribute_type: AttributeType | str | None = None,
+        set_attribute_type: str | AttributeType | None = None,
     ) -> ProcessedAnnotationData:
         """
         Process a complete annotation file and return structured data.
@@ -327,36 +367,51 @@ class EppiAnnotationConverter:
             attr.attribute_id: attr.attribute_label for attr in attributes
         }
 
+        all_annotations_raw = []
+        documents_by_title: dict[str, EppiDocument] = {}
+
+        for reference in data.get("References", []):
+            reference_codes = reference.get("Codes", [])
+            all_annotations_raw.extend(reference_codes)
+
+            doc_title = reference.get("Title", "")
+            # NL: really, the existing_ids thing is quite redundant here,
+            # as we assume we're getting our eppi item ids as document_ids.
+            # however, a) it demonstrates the desired functionality of
+            # checking against a set of already populated ids, and
+            # b) there is a world where eppi.jsons contain invalid item ids.
+            existing_ids: set[int] = set()
+            if doc_title and doc_title not in documents_by_title:
+                logger.debug(f"already populated ids in this job: {existing_ids!s} ")
+                document = EppiDocument(**reference)
+                # init doc id
+                new_id = document.init_document_identity(existing_ids=existing_ids)
+                if new_id:
+                    existing_ids.add(new_id)
+                documents_by_title[doc_title] = document
+
+        pdf_to_title_mapping = self._create_pdf_to_title_mapping(
+            data.get("References", [])
+        )
+
         annotated_documents = []
         all_annotations = []
-        documents_by_item_id: dict[int, EppiDocument] = {}
 
-        # Process each reference with its annotations directly
-        # Annotations are already nested within their parent reference
-        for reference in data.get("References", []):
-            item_id = reference.get("ItemId")
-            if item_id is None:
-                continue
+        for doc_title, doc in documents_by_title.items():
+            doc_annotations = self._find_document_annotations(
+                all_annotations_raw, doc_title, pdf_to_title_mapping
+            )
 
-            # Create or retrieve document using ItemId as unique identifier
-            if item_id not in documents_by_item_id:
-                document = EppiDocument.model_validate(reference)
-                documents_by_item_id[item_id] = document
-            else:
-                document = documents_by_item_id[item_id]
-
-            # Get annotations directly from this reference's Codes array
-            reference_codes = reference.get("Codes", [])
-            if reference_codes:
+            if doc_annotations:
                 annotations = self.convert_to_eppi_annotations(
-                    reference_codes,
+                    doc_annotations,
                     attributes_lookup,
                     attribute_id_to_label,
                 )
 
                 # Use model_construct to bypass validation and preserve all fields
                 annotated_doc = EppiGoldStandardAnnotatedDocument.model_construct(
-                    **{**document.__dict__, "annotations": annotations}
+                    **{**doc.__dict__, "annotations": annotations}
                 )
 
                 annotated_documents.append(annotated_doc)
@@ -364,14 +419,14 @@ class EppiAnnotationConverter:
 
         logger.info(
             f"Processed {len(attributes)} attributes,"
-            f" {len(documents_by_item_id)} documents, "
+            f" {len(documents_by_title)} documents, "
             f"{len(all_annotations)} annotations,"
             f" {len(annotated_documents)} annotated documents"
         )
 
         return ProcessedAnnotationData(
             attributes=attributes,
-            documents=list(documents_by_item_id.values()),
+            documents=list(documents_by_title.values()),
             annotations=all_annotations,
             annotated_documents=annotated_documents,
             attribute_id_to_label=attribute_id_to_label,


### PR DESCRIPTION
Reverts destiny-evidence/data-extraction-evaluation-toolkit#117

as it has broken eppi converter functionality, and we haven't got time to debug this right now, can bring this into main or linking once all of that functionality is working united

error:
```
(data-extraction-evaluation-toolkit) ➜  data-extraction-evaluation-toolkit git:(feature/cli) deet --verbose link-documents-fulltexts misc/reproduce/hpv/HPV_DataExtraction_Test.json --pdf-dir misc/reproduce/hpv/
default pdf parser: pdfminer

default epub parser: pandoc

default html parser: pandoc

default xml parser: pandoc

Processing annotation file: misc/reproduce/hpv/HPV_DataExtraction_Test.json

╭─────────────── Traceback (most recent call last) ───────────────╮
│ /Users/nikloynes/Dropbox/Work/ARC/projects/destiny/mini_repos/d │
│ ata-extraction-evaluation-toolkit/deet/scripts/cli.py:134 in    │
│ link_documents_fulltexts                                        │
│                                                                 │
│   131 │   from deet.processors.linker import DocumentReferenceL │
│   132 │                                                         │
│   133 │   converter = gs_data_format.get_annotation_converter() │
│ ❱ 134 │   processed_annotation_data = converter.process_annotat │
│   135 │                                                         │
│   136 │   linker = DocumentReferenceLinker(                     │
│   137 │   │   references=processed_annotation_data.documents,   │
│                                                                 │
│ /Users/nikloynes/Dropbox/Work/ARC/projects/destiny/mini_repos/d │
│ ata-extraction-evaluation-toolkit/deet/processors/eppi_annotati │
│ on_converter.py:367 in process_annotation_file                  │
│                                                                 │
│   364 │   │   │   # Get annotations directly from this referenc │
│   365 │   │   │   reference_codes = reference.get("Codes", [])  │
│   366 │   │   │   if reference_codes:                           │
│ ❱ 367 │   │   │   │   annotations = self.convert_to_eppi_annota │
│   368 │   │   │   │   │   reference_codes,                      │
│   369 │   │   │   │   │   attributes_lookup,                    │
│   370 │   │   │   │   │   attribute_id_to_label,                │
│                                                                 │
│ /Users/nikloynes/Dropbox/Work/ARC/projects/destiny/mini_repos/d │
│ ata-extraction-evaluation-toolkit/deet/processors/eppi_annotati │
│ on_converter.py:300 in convert_to_eppi_annotations              │
│                                                                 │
│   297 │   │                                                     │
│   298 │   │   """                                               │
│   299 │   │   return [                                          │
│ ❱ 300 │   │   │   self._convert_single_annotation(              │
│   301 │   │   │   │   annotation, attributes_lookup, attribute_ │
│   302 │   │   │   )                                             │
│   303 │   │   │   for annotation in annotations_data            │
│                                                                 │
│ /Users/nikloynes/Dropbox/Work/ARC/projects/destiny/mini_repos/d │
│ ata-extraction-evaluation-toolkit/deet/processors/eppi_annotati │
│ on_converter.py:262 in _convert_single_annotation               │
│                                                                 │
│   259 │   │   │   │   f"Attribute with ID {attribute_id} not fo │
│   260 │   │   │   │   "All annotations must reference a valid a │
│   261 │   │   │   )                                             │
│ ❱ 262 │   │   │   raise ValueError(attr_not_found_msg)          │
│   263 │   │                                                     │
│   264 │   │   # ensure the attribute has the correct label from │
│   265 │   │   if attribute_id_to_label is not None and attribut │
╰─────────────────────────────────────────────────────────────────╯
ValueError: Attribute with ID 17175911 not found in attributes
list. All annotations must reference a valid attribute from the
CodeSets
```