### PR TITLE
coerce annotations into list

### DIFF
--- a/deet/processors/eppi_annotation_converter.py
+++ b/deet/processors/eppi_annotation_converter.py
@@ -1,6 +1,7 @@
 """Convert annotation JSON files to Pydantic models."""
 
 import json
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
@@ -343,6 +344,27 @@ class EppiAnnotationConverter(AnnotationConverter):
 
         return doc_annotations
 
+    def _deduplicate_annotations(
+        self, annotations: list[EppiGoldStandardAnnotation]
+    ) -> list[EppiGoldStandardAnnotation]:
+        grouped = defaultdict(list)
+        for ann in annotations:
+            grouped[ann.attribute.attribute_id].append(ann)
+
+        collapsed_annotations = []
+
+        for anns in grouped.values():
+            base = anns[0]
+            if len(anns) == 1:
+                collapsed_annotations.append(base)
+                continue
+            values = [a.output_data for a in anns]
+
+            merged = base.model_copy(update={"output_data": values})
+            collapsed_annotations.append(merged)
+
+        return collapsed_annotations
+
     def process_annotation_file(
         self,
         file_path: str | Path,
@@ -424,6 +446,8 @@ class EppiAnnotationConverter(AnnotationConverter):
                     attributes_lookup,
                     attribute_id_to_label,
                 )
+                annotations = self._deduplicate_annotations(annotations)
+
             else:
                 annotations = []
 


### PR DESCRIPTION
# Pull Request

## Description
EppiJSONs sometimes contain multiple items in a codeset for a single document and a single attribute. Currently, we create multiple GoldStandardAnnotation objects for this, but this is not ideal, because what was *the* human annotation for attribute x in document y? (see `GoldStandardAnnotatedDocument.get_attribute_annotation`).

This is just eppi's way of representing a list (0 or more strings representing the data type being extracted), and we should represent this as a list when we parse the data.

This PR has some ideas for fixing this, but is not working properly yet.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [ ] All existing and new tests pass locally and in CI
- [ ] Core functionality still works locally (e.g. all pipeline scripts)
- [ ] Code passes `ruff` linting
- [ ] Code passes `mypy` type checking
- [ ] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [ ] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
<!-- Describe how you tested your changes, interactively and formally. -->

## Additional Notes
<!-- Other context, screenshots, or information reviewers should know. Keep in mind text is better than a screenshot of text. -->

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
