### PR TITLE
add newline and encoding for linkage mapper creation

### DIFF
--- a/deet/data_models/processed_gold_standard_annotations.py
+++ b/deet/data_models/processed_gold_standard_annotations.py
@@ -316,11 +316,7 @@ class ProcessedAnnotationData(
 
     def export_linkage_mapper_csv(self, file_path: Path) -> None:
         """Export a csv mapper to link document IDs and filenames."""
-<<<<<<< HEAD
         with file_path.open("w", newline="", encoding="utf-8") as f:
-=======
-        with file_path.open("w", encoding="utf-8") as f:
->>>>>>> main
             writer = csv.DictWriter(f, fieldnames=["document_id", "name", "file_path"])
             writer.writeheader()
             for d in self.documents:


### PR DESCRIPTION
# Pull Request

## Description
The linkage mapper had empty rows in windows. It shouldn't anymore with this fix

## Related Issue(s)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [ ] All existing and new tests pass locally and in CI
- [ ] Core functionality still works locally (e.g. all pipeline scripts)
- [ ] Code passes `ruff` linting
- [ ] Code passes `mypy` type checking
- [ ] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [ ] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
<!-- Describe how you tested your changes, interactively and formally. -->

## Additional Notes
<!-- Other context, screenshots, or information reviewers should know. Keep in mind text is better than a screenshot of text. -->

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
