### PR TITLE
further specification of schema - additionalProperties: False

### DIFF
--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -94,8 +94,11 @@ class AttributeType(StrEnum):
             AttributeType.INTEGER: {"type": "integer"},
             AttributeType.FLOAT: {"type": "number"},
             AttributeType.BOOL: {"type": "boolean"},
-            AttributeType.LIST: {"type": "array", "items": {}},
-            AttributeType.DICT: {"type": "object", "additionalProperties": True},
+            AttributeType.LIST: {
+                "type": "array",
+                "items": {"type": "object", "additionalProperties": False},
+            },
+            AttributeType.DICT: {"type": "object", "additionalProperties": False},
         }
         return mapping[self]
 


### PR DESCRIPTION
# Pull Request

## Description
For some reason, when run installed with `uv tool install git+https://github.com/destiny-evidence/data-extraction-evaluation-toolkit.git`, litellm calls to Azure fail with 

```python
litellm.ContentPolicyViolationError: AzureException - Invalid schema for response_format 'llm_annotation_response'
```

#147 fixed one of these errors, but there were further Azure constraints which this PR now fixes, that required further specifying the schema.

## Related Issue(s)
#212 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing

```sh
uv tool install --reinstall git+https://github.com/destiny-evidence/data-extraction-evaluation-toolkit.git@fix-azure-schema-issues-uv-tool
deet test-llm-config
```

## Additional Notes
<!-- Other context, screenshots, or information reviewers should know. Keep in mind text is better than a screenshot of text. -->

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
