### PR TITLE
prevent duplication of echo_and_log using filter and logger.bind

### DIFF
--- a/deet/scripts/cli.py
+++ b/deet/scripts/cli.py
@@ -404,8 +404,13 @@ def global_options(
     *, verbose: bool = typer.Option(default=False, help="Display verbose logs.")
 ) -> None:
     """Set global options for all deet commands."""
-    level = "DEBUG" if verbose else "INFO"
-    logger.add(typer.echo, colorize=True, level=level)
+    log_level = "DEBUG" if verbose else "INFO"
+    logger.add(
+        typer.echo,
+        colorize=True,
+        level=log_level,
+        filter=lambda record: "is_echo" not in record["extra"],
+    )
     if not verbose:
         warnings.filterwarnings("ignore", message=".*is ill-defined.*")
 

--- a/deet/utils/cli_utils.py
+++ b/deet/utils/cli_utils.py
@@ -31,7 +31,7 @@ def echo_and_log(message: Any, **kwargs) -> None:  # noqa: ANN401
     NOTE: pass typer-style stuff via kwargs.
     """
     typer.secho(message, **kwargs)
-    logger.info(f"typer .secho: {message}")
+    logger.bind(is_echo=True).info(f"typer .secho: {message}")
 
 
 def fail_with_message(message: str) -> NoReturn:

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -13,11 +13,13 @@ def test_echo_and_log(capsys):
     test_message = "Test message for echo and log"
 
     with patch("deet.utils.cli_utils.logger") as mock_logger:
+        mock_logger.bind.return_value = mock_logger
         echo_and_log(test_message)
 
-    # check stdout (typer echo/secho) contains the message
+    # check stdout (typer echo/secho) contains the message once
     captured = capsys.readouterr()
-    assert test_message in captured.out
+    occurences = captured.out.count(test_message)
+    assert occurences == 1
 
     # check logger.info was called with the message
     mock_logger.info.assert_called_once()


### PR DESCRIPTION
# Pull Request

## Description
Since the CLI, `deet.cli_utils.echo_and_log` has given us the opportunity to use typer.secho (including nice formatting for high-level CLI feedback) while also logging the message. Since logs are redirected into typer.echo, we get the messages twice.

This PR attaches a filter to the typer.echo log sink, to prevent duplication. It also amends the echo_and_log test to test not only whether messages appear but also that they appear once.

## Related Issue(s)
Closes #214 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing

Ran `deet export-config-template` and established that messages are written to stdout once, and to file once. Amended test to test not only that the test message appears but that it appears once.

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
