### PR TITLE
Strip BOM and whitespace from CSV header names

### DIFF
--- a/deet/data_models/processed_gold_standard_annotations.py
+++ b/deet/data_models/processed_gold_standard_annotations.py
@@ -197,6 +197,13 @@ class ProcessedAttributeData(BaseModel, Generic[AttributeTypeVar]):
 
         with filepath.open(mode="r", newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f)
+
+            if reader.fieldnames is not None:
+                reader.fieldnames = [
+                    name.lstrip("\ufeff").strip() if name else name
+                    for name in reader.fieldnames
+                ]
+                
             self._validate_csv_headers(reader.fieldnames)
 
             for row in reader:

--- a/deet/data_models/processed_gold_standard_annotations.py
+++ b/deet/data_models/processed_gold_standard_annotations.py
@@ -197,13 +197,12 @@ class ProcessedAttributeData(BaseModel, Generic[AttributeTypeVar]):
 
         with filepath.open(mode="r", newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f)
-
             if reader.fieldnames is not None:
                 reader.fieldnames = [
                     name.lstrip("\ufeff").strip() if name else name
                     for name in reader.fieldnames
                 ]
-                
+
             self._validate_csv_headers(reader.fieldnames)
 
             for row in reader:


### PR DESCRIPTION
# Pull Request

### Description
Excel adds "\ufeff" to the beginning of a CSV file, which then causes DEET to read the 'prompt' column heading as '\ufeffprompt' while not being able to print this out for the user (because the BOM is an invisible field)

### Definition of Done

- [x] prompt_csv saved by excel with BOM can be read
- [x] prompt_csv with normal utf-8 can still be read


## Related Issue(s)
#226 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI --> No new tests added. One test fails 'AssertionError: assert '\\bin\\python' == '/bin/python' in tests/unit/test_pipeline.py::test_executors_script_executor_dispatch BUT I assume this is a neglegible error to do with Windows.
- [ ] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking --> I think so? 
- [ ] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable) --> Not applicable because no new functions were added
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
I tested this on a utf-8-BOM file and the same file as simple utf-8, to ensure that the BOM stripping does not cause issues in files that are not affected

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
