### PR TITLE
Feature/evaluator fails gracefully

### DIFF
--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -24,7 +24,9 @@ from deet.data_models.base import (
 )
 from deet.exceptions import (
     BadDocumentIdError,
+    DuplicateAnnotationError,
     MissingCitationElementError,
+    MissingDocumentError,
     NoAbstractError,
 )
 from deet.processors.parser import ParsedOutput
@@ -531,7 +533,7 @@ class GoldStandardAnnotatedDocument(
                         f"attribute: {attribute.attribute_label}. We don't know how to"
                         "interpret which is the canonical version."
                     )
-                    raise ValueError(multiple_matches)
+                    raise DuplicateAnnotationError(multiple_matches)
                 result = annotation
 
         if result is None:
@@ -586,4 +588,4 @@ class GoldStandardAnnotatedDocumentList(
         except KeyError as err:
             not_found = f"Document with ID {document_id} not found in annotated"
             " doc list"
-            raise ValueError(not_found) from err
+            raise MissingDocumentError(not_found) from err

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -7,6 +7,7 @@ import csv
 from collections.abc import Sequence
 from itertools import groupby
 from pathlib import Path
+from typing import Any
 
 import sklearn.metrics  # type:ignore[import-untyped]
 from loguru import logger
@@ -94,7 +95,7 @@ class GoldStandardLLMEvaluator:
                 f"Calculating metric for attribute: {attribute.attribute_label}"
             )
             y_true = []
-            y_pred = []
+            y_pred: list[Any] = []
             for document in self.gold_standard_annotated_documents:
                 logger.debug(
                     f"Extracting gold standard and LLM prediction for"
@@ -103,9 +104,15 @@ class GoldStandardLLMEvaluator:
                 gs_val = document.get_attribute_annotation(attribute).output_data
                 y_true.append(gs_val)
 
-                llm_doc = self.llm_annotated_documents.get_by_id(
-                    document.document.safe_identity.document_id
-                )
+                try:
+                    llm_doc = self.llm_annotated_documents.get_by_id(
+                        document.document.safe_identity.document_id
+                    )
+                except ValueError:
+                    y_pred.append(None)
+                    missing_id = document.document.safe_identity.document_id
+                    logger.warning(f"LLM annotated doc not found - ID: {missing_id}")
+                    continue
                 llm_val = llm_doc.get_attribute_annotation(attribute).output_data
                 y_pred.append(llm_val)
 
@@ -117,6 +124,7 @@ class GoldStandardLLMEvaluator:
             for metric_name, metric_fn in combined_metrics.items():
                 try:
                     value = float(metric_fn(y_true, y_pred))
+                    logger.warning(f"It worked for {metric_name}!")
                 except (ValueError, TypeError) as e:
                     logger.warning(
                         f"Metric '{metric_name}' not applicable for "

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -129,7 +129,6 @@ class GoldStandardLLMEvaluator:
             for metric_name, metric_fn in combined_metrics.items():
                 try:
                     value = float(metric_fn(y_true, y_pred))
-                    logger.warning(f"It worked for {metric_name}!")
                 except (ValueError, TypeError) as e:
                     logger.warning(
                         f"Metric '{metric_name}' not applicable for "

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -208,10 +208,32 @@ class GoldStandardLLMEvaluator:
             )
             writer.writeheader()
             for doc in self.gold_standard_annotated_documents:
-                llm_annotation = self.llm_annotated_documents.get_by_id(
-                    doc.document.safe_identity.document_id
-                )
+                try:
+                    llm_annotated_doc = self.llm_annotated_documents.get_by_id(
+                        doc.document.safe_identity.document_id
+                    )
+                except ValueError:
+                    llm_annotated_doc = None
                 for attribute in self.attributes:
+                    if llm_annotated_doc is None:
+                        llm_extraction = None
+                        llm_reasoning: str | None = (
+                            "LLM did not produce an output for this document."
+                            " Check the logs carefully to find out why"
+                        )
+                    else:
+                        try:
+                            llm_annotation = llm_annotated_doc.get_attribute_annotation(
+                                attribute
+                            )
+                            llm_extraction = llm_annotation.output_data
+                            llm_reasoning = llm_annotation.reasoning
+                        except ValueError:
+                            llm_extraction = None
+                            llm_reasoning = (
+                                "The LLM produced multiple annotations"
+                                "for this single attribute"
+                            )
                     writer.writerow(
                         {
                             "document_id": doc.document.safe_identity.document_id,
@@ -221,12 +243,8 @@ class GoldStandardLLMEvaluator:
                             "human_extraction": doc.get_attribute_annotation(
                                 attribute
                             ).output_data,
-                            "llm_extraction": llm_annotation.get_attribute_annotation(
-                                attribute
-                            ).output_data,
-                            "llm_reasoning": llm_annotation.get_attribute_annotation(
-                                attribute
-                            ).reasoning,
+                            "llm_extraction": llm_extraction,
+                            "llm_reasoning": llm_reasoning,
                             "extraction_run_id": self.extraction_run_id,
                         }
                     )

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -26,6 +26,7 @@ from deet.data_models.evaluation import (
     check_metric_returns_float,
     get_metrics_for_attribute_type,
 )
+from deet.exceptions import DuplicateAnnotationError, MissingDocumentError
 
 
 class GoldStandardLLMEvaluator:
@@ -106,13 +107,13 @@ class GoldStandardLLMEvaluator:
 
                 try:
                     llm_doc = self.llm_annotated_documents.get_by_id(doc_id)
-                except ValueError:
+                except MissingDocumentError:
                     y_pred.append(None)
                     logger.warning(f"LLM annotated doc not found - ID: {doc_id}")
                     continue
                 try:
                     llm_val = llm_doc.get_attribute_annotation(attribute).output_data
-                except ValueError:
+                except DuplicateAnnotationError:
                     llm_val = None
                     logger.warning(
                         f"LLM produced multiple annotations for a single"
@@ -212,7 +213,7 @@ class GoldStandardLLMEvaluator:
                     llm_annotated_doc = self.llm_annotated_documents.get_by_id(
                         doc.document.safe_identity.document_id
                     )
-                except ValueError:
+                except MissingDocumentError:
                     llm_annotated_doc = None
                 for attribute in self.attributes:
                     if llm_annotated_doc is None:
@@ -228,7 +229,7 @@ class GoldStandardLLMEvaluator:
                             )
                             llm_extraction = llm_annotation.output_data
                             llm_reasoning = llm_annotation.reasoning
-                        except ValueError:
+                        except DuplicateAnnotationError:
                             llm_extraction = None
                             llm_reasoning = (
                                 "The LLM produced multiple annotations"

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -97,23 +97,27 @@ class GoldStandardLLMEvaluator:
             y_true = []
             y_pred: list[Any] = []
             for document in self.gold_standard_annotated_documents:
+                doc_id = document.document.safe_identity.document_id
                 logger.debug(
-                    f"Extracting gold standard and LLM prediction for"
-                    f" doc {document.document.safe_identity.document_id}"
+                    f"Extracting gold standard and LLM prediction for" f" doc {doc_id}"
                 )
                 gs_val = document.get_attribute_annotation(attribute).output_data
                 y_true.append(gs_val)
 
                 try:
-                    llm_doc = self.llm_annotated_documents.get_by_id(
-                        document.document.safe_identity.document_id
-                    )
+                    llm_doc = self.llm_annotated_documents.get_by_id(doc_id)
                 except ValueError:
                     y_pred.append(None)
-                    missing_id = document.document.safe_identity.document_id
-                    logger.warning(f"LLM annotated doc not found - ID: {missing_id}")
+                    logger.warning(f"LLM annotated doc not found - ID: {doc_id}")
                     continue
-                llm_val = llm_doc.get_attribute_annotation(attribute).output_data
+                try:
+                    llm_val = llm_doc.get_attribute_annotation(attribute).output_data
+                except ValueError:
+                    llm_val = None
+                    logger.warning(
+                        f"LLM produced multiple annotations for a single"
+                        f" attribute with doc: {doc_id}"
+                    )
                 y_pred.append(llm_val)
 
             applicable_metrics = get_metrics_for_attribute_type(

--- a/deet/exceptions.py
+++ b/deet/exceptions.py
@@ -1,6 +1,26 @@
 """Custom exceptions."""
 
 
+class MissingDocumentError(Exception):
+    """
+    Raise when looking up a document by id fails.
+
+    Args:
+        Exception (_type_):
+
+    """
+
+
+class DuplicateAnnotationError(Exception):
+    """
+    Raise when multiple annotations for a single attribute are present.
+
+    Args:
+        Exception (_type_):
+
+    """
+
+
 class InvalidInputFileTypeError(Exception):
     """
     Raise when user supplies a not permitted input file type.

--- a/tests/unit/test_gold_standard_llm_evaluator.py
+++ b/tests/unit/test_gold_standard_llm_evaluator.py
@@ -107,6 +107,38 @@ def test_evaluator_fails_gracefully_missing_doc(
 
 
 @pytest.fixture
+def processed_data_duplicated_annotations(processed_data):
+    """Create ProcessedEppiAnnotationData with test attributes."""
+    processed_data_duplicated_annotations = deepcopy(processed_data)
+    for doc in processed_data_duplicated_annotations.annotated_documents:
+        doc.annotations = doc.annotations + doc.annotations
+    return processed_data_duplicated_annotations
+
+
+# When an llm returns multiple values for the same attribute, metrics should be None
+# and we should warn rather than fail
+def test_evaluator_fails_gracefully_duplicated_annotations(
+    processed_data, processed_data_duplicated_annotations
+):
+    messages = []
+    logger_id = logger.add(messages.append, level="WARNING")
+    evaluator = GoldStandardLLMEvaluator(
+        gold_standard_annotated_documents=processed_data.annotated_documents,
+        llm_annotated_documents=processed_data_duplicated_annotations.annotated_documents,
+        attributes=[processed_data.attributes[0]],
+        extraction_run_id="",
+    )
+    evaluator.evaluate_llm_annotations()
+    for m in evaluator.calculated_metrics:
+        if m.metric_name != "n_labels":
+            assert m.value is None
+
+    logger.remove(logger_id)
+    warn_string = "LLM produced multiple annotations for a single attribute"
+    assert any(warn_string in m for m in messages)
+
+
+@pytest.fixture
 def evaluator_evaluated(processed_data):
     evaluator = GoldStandardLLMEvaluator(
         gold_standard_annotated_documents=processed_data.annotated_documents,

--- a/tests/unit/test_gold_standard_llm_evaluator.py
+++ b/tests/unit/test_gold_standard_llm_evaluator.py
@@ -99,10 +99,11 @@ def test_evaluator_fails_gracefully_missing_doc(
     )
     evaluator.evaluate_llm_annotations()
     for m in evaluator.calculated_metrics:
-        assert m.value is None
+        if m.metric_name != "n_labels":
+            assert m.value is None
 
     logger.remove(logger_id)
-    assert any("not found in annotated" in m for m in messages)
+    assert any("LLM annotated doc not found" in m for m in messages)
 
 
 @pytest.fixture

--- a/tests/unit/test_gold_standard_llm_evaluator.py
+++ b/tests/unit/test_gold_standard_llm_evaluator.py
@@ -1,4 +1,5 @@
 import csv
+from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
@@ -71,6 +72,37 @@ def test_evaluator_evaluates_with_nonfloat_metric(processed_data):
     evaluator.evaluate_llm_annotations()
     for metric in evaluator.calculated_metrics:
         assert metric.value == 1
+
+
+@pytest.fixture
+def processed_data_missing_doc(processed_data):
+    """Create ProcessedEppiAnnotationData with test attributes."""
+    processed_data_missing_doc = deepcopy(processed_data)
+    processed_data_missing_doc.annotated_documents = processed_data.annotated_documents[
+        :-1
+    ]
+    return processed_data_missing_doc
+
+
+# When a doc is missing from llm_preds, metrics should be None
+# and we should warn rather than fail
+def test_evaluator_fails_gracefully_missing_doc(
+    processed_data, processed_data_missing_doc
+):
+    messages = []
+    logger_id = logger.add(messages.append, level="WARNING")
+    evaluator = GoldStandardLLMEvaluator(
+        gold_standard_annotated_documents=processed_data.annotated_documents,
+        llm_annotated_documents=processed_data_missing_doc.annotated_documents,
+        attributes=[processed_data.attributes[0]],
+        extraction_run_id="",
+    )
+    evaluator.evaluate_llm_annotations()
+    for m in evaluator.calculated_metrics:
+        assert m.value is None
+
+    logger.remove(logger_id)
+    assert any("not found in annotated" in m for m in messages)
 
 
 @pytest.fixture

--- a/tests/unit/test_gold_standard_llm_evaluator.py
+++ b/tests/unit/test_gold_standard_llm_evaluator.py
@@ -87,7 +87,7 @@ def processed_data_missing_doc(processed_data):
 # When a doc is missing from llm_preds, metrics should be None
 # and we should warn rather than fail
 def test_evaluator_fails_gracefully_missing_doc(
-    processed_data, processed_data_missing_doc
+    processed_data, processed_data_missing_doc, tmp_path
 ):
     messages = []
     logger_id = logger.add(messages.append, level="WARNING")
@@ -105,6 +105,8 @@ def test_evaluator_fails_gracefully_missing_doc(
     logger.remove(logger_id)
     assert any("LLM annotated doc not found" in m for m in messages)
 
+    evaluator.export_llm_comparison(tmp_path / "llm_human_comparison.csv")
+
 
 @pytest.fixture
 def processed_data_duplicated_annotations(processed_data):
@@ -118,7 +120,7 @@ def processed_data_duplicated_annotations(processed_data):
 # When an llm returns multiple values for the same attribute, metrics should be None
 # and we should warn rather than fail
 def test_evaluator_fails_gracefully_duplicated_annotations(
-    processed_data, processed_data_duplicated_annotations
+    processed_data, processed_data_duplicated_annotations, tmp_path
 ):
     messages = []
     logger_id = logger.add(messages.append, level="WARNING")
@@ -136,6 +138,8 @@ def test_evaluator_fails_gracefully_duplicated_annotations(
     logger.remove(logger_id)
     warn_string = "LLM produced multiple annotations for a single attribute"
     assert any(warn_string in m for m in messages)
+
+    evaluator.export_llm_comparison(tmp_path / "llm_human_comparison.csv")
 
 
 @pytest.fixture


### PR DESCRIPTION
# Pull Request

## Description
In evaluation code, looking up LLM annotations resulted in an error if an LLM annotation was not produced, or if the LLM produced more than one annotation for the same attribute.

Now, this causes a warning, and for metrics to evaluate to None, but the command finishes running and outputs are generated

## Related Issue(s)
Closes #228 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
Wrote test fixtures for mising/duplicated llm annotation data, and tests for how we want it to behave. 

## Additional Notes
<!-- Other context, screenshots, or information reviewers should know. Keep in mind text is better than a screenshot of text. -->

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
