### PR TITLE
minor fix to EppiDocument class to deal with empty strings for years

### DIFF
--- a/deet/data_models/eppi.py
+++ b/deet/data_models/eppi.py
@@ -227,6 +227,14 @@ class EppiDocument(Document):
     )
     doi: str | None = Field(default=None, validation_alias=AliasChoices("DOI", "doi"))
 
+    @field_validator("year", mode="before")
+    @classmethod
+    def empty_year_string_to_none(cls, value: str) -> str | None:
+        """Parse an empty string year to None or return as is."""
+        if value == "":
+            return None
+        return value
+
     @field_validator("date_created", mode="before")
     @classmethod
     def parse_date_string(cls, value: str) -> datetime | None:


### PR DESCRIPTION
# Pull Request

## Description
adds a validator to `EppiDocument` to convert empty strings in `year` field to `None`.

## Related Issue(s)
Closes #224
Closes #199 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
Passes tests; @L-ENA to test with real, complex data once this PR is inside #248.


---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
