### PR TITLE
Feature/internal external ids

### DIFF
--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -192,7 +192,10 @@ class DocumentIdentity(BaseModel):
         return id_creation_map[id_source]
 
     def _eppi_item_id(self) -> int:
-        """Map an existing item_id (parsed as document_id)."""
+        """
+        Map an existing item_id (parsed as external_id
+        in DocumentIdentity instance).
+        """
         # we're going to assume that our `document_id`, received
         # from parsing eppi-json to EppiDocument is always going
         # to be eppi, otherwise this method should be extended to

--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -69,7 +69,6 @@ class DocumentIdentity(BaseModel):
 
     document_id: int | None = None
     document_id_source: DocumentIDSource | None = None
-    # external_id: str | int | None = None
     external_id: str | int | None = None
 
     # parsed citation info

--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -65,7 +65,20 @@ class DocumentIDSource(StrEnum):
 
 
 class DocumentIdentity(BaseModel):
-    """A unified identity for a document, deriveable from multiple sources."""
+    """
+    A unified identity for a document, deriveable from multiple sources.
+
+    `document_id`:
+        always int, the canonical internal id assigned by deet.
+        in current implementation, mirrors eppi item ids.
+    `internal_id`:
+        a symlink to `document_id`.
+    `external_id`:
+        ID inherited verbatim from source citation/gold standard
+        data. this can be string or int, no validation is performed on
+        it.
+
+    """
 
     document_id: int | None = None
     document_id_source: DocumentIDSource | None = None

--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -69,11 +69,17 @@ class DocumentIdentity(BaseModel):
 
     document_id: int | None = None
     document_id_source: DocumentIDSource | None = None
+    external_id: str | int | None = None
 
     # parsed citation info
     doi: str | None
     first_author: str | None
     year: str | None
+
+    @property
+    def internal_id(self) -> int | None:
+        """Return the internal ID (alias for document_id for backward compatibility)."""
+        return self.document_id
 
     def populate_id(
         self,
@@ -200,6 +206,9 @@ class DocumentIdentity(BaseModel):
         ):
             digit_count = len(str(abs(self.document_id)))
             if MIN_DOCUMENT_ID_DIGITS <= digit_count <= MAX_DOCUMENT_ID_DIGITS:
+                # Set external_id to the original document_id for EPPi item IDs
+                if self.external_id is None:
+                    self.external_id = self.document_id
                 return self.document_id
         bad_doc_id = f"id {self.document_id} is not a valid eppi item_id."
         raise BadDocumentIdError(bad_doc_id)
@@ -356,6 +365,7 @@ class Document(BaseModel):
         labs_ref = LabsReference(reference=self.citation)  # convert for easy access
         self.document_identity = DocumentIdentity(
             document_id=self.document_id,
+            external_id=self.document_id,
             doi=labs_ref.doi,
             first_author=labs_ref.first_author,
             year=str(labs_ref.publication_year),

--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -69,6 +69,7 @@ class DocumentIdentity(BaseModel):
 
     document_id: int | None = None
     document_id_source: DocumentIDSource | None = None
+    # external_id: str | int | None = None
     external_id: str | int | None = None
 
     # parsed citation info
@@ -200,17 +201,17 @@ class DocumentIdentity(BaseModel):
         # Either way, it must be a positive integer with a number of digits
         # between MIN_DOCUMENT_ID_DIGITS and MAX_DOCUMENT_ID_DIGITS (inclusive).
         if (
-            self.document_id is not None
-            and isinstance(self.document_id, int)
-            and self.document_id > 0
+            self.external_id is not None
+            and isinstance(self.external_id, int)
+            and self.external_id > 0
         ):
-            digit_count = len(str(abs(self.document_id)))
+            digit_count = len(str(abs(self.external_id)))
             if MIN_DOCUMENT_ID_DIGITS <= digit_count <= MAX_DOCUMENT_ID_DIGITS:
                 # Set external_id to the original document_id for EPPi item IDs
-                if self.external_id is None:
-                    self.external_id = self.document_id
+                if self.document_id is None:
+                    self.document_id = self.external_id
                 return self.document_id
-        bad_doc_id = f"id {self.document_id} is not a valid eppi item_id."
+        bad_doc_id = f"id {self.external_id} is not a valid eppi item_id."
         raise BadDocumentIdError(bad_doc_id)
 
     def _citation_id_hasher(self, target_fields: list[str]) -> int:
@@ -272,7 +273,7 @@ class Document(BaseModel):
     citation: ReferenceFileInput
     context: str | None = None  # new defaults, empty
     context_type: ContextType | None = ContextType.EMPTY
-    document_id: int | None = None
+    document_id: int | str | None = None  # add support for str ids, e.g. uuid
     document_identity: DocumentIdentity | None = None
 
     parsed_document: ParsedOutput | None = None
@@ -364,7 +365,7 @@ class Document(BaseModel):
         """Initialise document_identity field using available metadata."""
         labs_ref = LabsReference(reference=self.citation)  # convert for easy access
         self.document_identity = DocumentIdentity(
-            document_id=self.document_id,
+            document_id=None,
             external_id=self.document_id,
             doi=labs_ref.doi,
             first_author=labs_ref.first_author,

--- a/deet/data_models/eppi.py
+++ b/deet/data_models/eppi.py
@@ -227,6 +227,14 @@ class EppiDocument(Document):
     )
     doi: str | None = Field(default=None, validation_alias=AliasChoices("DOI", "doi"))
 
+    @field_validator("year", mode="before")
+    @classmethod
+    def empty_year_string_to_none(cls, value: str) -> str | None:
+        """Parse an empty string year to None or return as is."""
+        if value == "":
+            return None
+        return value
+
     @field_validator("date_created", mode="before")
     @classmethod
     def parse_date_string(cls, value: str) -> datetime | None:

--- a/deet/data_models/eppi.py
+++ b/deet/data_models/eppi.py
@@ -231,11 +231,20 @@ class EppiDocument(Document):
 
     @field_validator("year", mode="before")
     @classmethod
-    def empty_year_string_to_none(cls, value: str) -> str | None:
+    def empty_year_string_to_none(cls, value: Any) -> int | None:  # noqa:ANN401
         """Parse an empty string year to None or return as is."""
-        if value == "":
+        if value == "" or value is None:
             return None
-        return value
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            stripped_value = value.strip()
+            if stripped_value == "":
+                return None
+            if stripped_value.isdigit():
+                return int(stripped_value)
+        bad_year = f"unable to parse year: {value!r}"
+        raise ValueError(bad_year)
 
     @field_validator("date_created", mode="before")
     @classmethod

--- a/deet/data_models/eppi.py
+++ b/deet/data_models/eppi.py
@@ -191,7 +191,9 @@ class EppiDocument(Document):
     """
 
     name: str = Field(default="", validation_alias=AliasChoices("Title", "name"))
-    document_id: int = Field(validation_alias=AliasChoices("ItemId", "document_id"))
+    document_id: int | str = Field(
+        validation_alias=AliasChoices("ItemId", "document_id")
+    )
 
     model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)  # type: ignore[typeddict-unknown-key]
 

--- a/deet/data_models/processed_gold_standard_annotations.py
+++ b/deet/data_models/processed_gold_standard_annotations.py
@@ -328,19 +328,30 @@ class ProcessedAnnotationData(
         path_type: Literal["full", "relative", "file"] = "file",
     ) -> None:
         """Export a csv mapper to link document IDs and filenames."""
+        existing_ids: set[int] = set()
+        for d in self.documents:
+            if d.document_identity is None or d.document_identity.document_id is None:
+                d.init_document_identity(existing_ids=existing_ids)
+            if d.document_identity and d.document_identity.document_id is not None:
+                existing_ids.add(d.document_identity.document_id)
+
         pre_fill: dict[int, Path] = {}
         if document_base_dir is not None:
             linker = DocumentReferenceLinker(
                 references=self.documents,
                 document_base_dir=document_base_dir,
             )
+            # Use all available strategies including FILENAME_EXTERNAL_ID
+            # for better coverage
             pre_fill = linker.guess_file_paths()
             logger.info(
                 f"pre-filled {len(pre_fill)} file paths from {document_base_dir}"
             )
 
         with file_path.open("w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=["document_id", "name", "file_path"])
+            writer = csv.DictWriter(
+                f, fieldnames=["document_id", "external_id", "name", "file_path"]
+            )
             writer.writeheader()
             for d in self.documents:
                 if (
@@ -349,20 +360,21 @@ class ProcessedAnnotationData(
                 ):
                     d.init_document_identity()
                 doc_id = d.document_identity.document_id  # type: ignore[union-attr]
+                external_id = d.document_identity.external_id  # type: ignore[union-attr]
                 if doc_id is None:
                     no_doc_identity_err = (
                         f"document_identity was not set for document {d}"
                     )
                     raise ValueError(no_doc_identity_err)
 
-                file_path = pre_fill.get(doc_id)  # type:ignore[assignment]
-                if isinstance(file_path, Path):
+                file_path_result = pre_fill.get(doc_id)  # type:ignore[assignment]
+                if isinstance(file_path_result, Path):
                     if path_type == "full":
-                        file_path = file_path.absolute()
+                        file_path_result = file_path_result.absolute()
                     elif path_type == "relative":
                         pass
                     elif path_type == "file":
-                        file_path = Path(file_path.name)
+                        file_path_result = Path(file_path_result.name)
                     else:
                         bad_filepath_formatting_err = (
                             f"path_type {path_type} is "
@@ -371,7 +383,12 @@ class ProcessedAnnotationData(
                         raise NotImplementedError(bad_filepath_formatting_err)
 
                 writer.writerow(
-                    {"document_id": doc_id, "name": d.name, "file_path": file_path}
+                    {
+                        "document_id": doc_id,
+                        "external_id": external_id,
+                        "name": d.name,
+                        "file_path": file_path_result,
+                    }
                 )
 
 

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -100,7 +100,7 @@ class GoldStandardLLMEvaluator:
             for document in self.gold_standard_annotated_documents:
                 doc_id = document.document.safe_identity.document_id
                 logger.debug(
-                    f"Extracting gold standard and LLM prediction for" f" doc {doc_id}"
+                    f"Extracting gold standard and LLM prediction for doc {doc_id}"
                 )
                 gs_val = document.get_attribute_annotation(attribute).output_data
                 y_true.append(gs_val)

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -197,6 +197,7 @@ class GoldStandardLLMEvaluator:
                 f,
                 fieldnames=[
                     "document_id",
+                    "external_id",
                     "document_name",
                     "attribute_id",
                     "attribute_label",
@@ -237,6 +238,7 @@ class GoldStandardLLMEvaluator:
                     writer.writerow(
                         {
                             "document_id": doc.document.safe_identity.document_id,
+                            "external_id": doc.document.safe_identity.external_id,
                             "document_name": doc.document.name,
                             "attribute_id": attribute.attribute_id,
                             "attribute_label": attribute.attribute_label,

--- a/deet/processors/eppi_annotation_converter.py
+++ b/deet/processors/eppi_annotation_converter.py
@@ -372,9 +372,9 @@ class EppiAnnotationConverter(AnnotationConverter):
                     attribute_id_to_label,
                 )
 
-                # Use model_construct to bypass validation and preserve all fields
-                annotated_doc = EppiGoldStandardAnnotatedDocument.model_construct(
-                    **{**document.__dict__, "annotations": annotations}
+                annotated_doc = EppiGoldStandardAnnotatedDocument(
+                    document=document,
+                    annotations=annotations,
                 )
 
                 annotated_documents.append(annotated_doc)

--- a/deet/processors/linker.py
+++ b/deet/processors/linker.py
@@ -367,8 +367,8 @@ class DocumentReferenceLinker:
         logger.debug(self._references_by_id.keys())
 
         logger.debug("populating _references_by_external_id lookup...")
-        self._references_by_external_id: dict[int | str, Document] = {
-            doc.document_identity.external_id: doc  # type:ignore[union-attr]
+        self._references_by_external_id: dict[str, Document] = {
+            str(doc.document_identity.external_id): doc  # type:ignore[union-attr]
             for doc in tmp_refs
             if doc.document_identity.external_id is not None  # type:ignore[union-attr]
         }
@@ -596,12 +596,8 @@ class DocumentReferenceLinker:
             if file.suffix not in [".md", ".pdf"]:
                 logger.warning(f"file {file} is not pdf/md. next!")
                 continue
-            try:
-                # Extract ID from filename (everything before the extension)
-                id_guess = file.name.split(".")[0]
-            except ValueError:
-                logger.debug(f"{file.name} isn't convertible to int. next!")
-                continue
+            # ID from filename
+            id_guess = str(file.stem)
 
             # Try to find document by external ID
             unlinked_doc = self._references_by_external_id.get(id_guess)

--- a/deet/processors/linker.py
+++ b/deet/processors/linker.py
@@ -26,6 +26,7 @@ class LinkingStrategy(StrEnum):
     FILENAME_AUTHOR_YEAR_LONGEST = auto()
     FILENAME_AUTHOR_YEAR_LAST = auto()
     FILENAME_ID = auto()
+    FILENAME_EXTERNAL_ID = auto()
     # to add: some sort of interactive selection thing in CLI
     # or, later on, in UI.
 
@@ -332,6 +333,7 @@ class DocumentReferenceLinker:
     LINKING_STRATEGY_HIERARCHY = [
         LinkingStrategy.MAPPING_FILE,
         LinkingStrategy.FILENAME_ID,
+        LinkingStrategy.FILENAME_EXTERNAL_ID,
     ]
 
     def __init__(
@@ -356,13 +358,24 @@ class DocumentReferenceLinker:
         self.documents_references = references
 
         # lookup dicts for O(1) id & author_year based lookup
+        logger.debug("populating _references_by_id lookup...")
         self._references_by_id: dict[int, Document] = {
             doc.document_identity.document_id: doc  # type:ignore[union-attr]
             for doc in tmp_refs
             if doc.document_identity.document_id is not None  # type:ignore[union-attr]
         }
         logger.debug(self._references_by_id.keys())
+
+        logger.debug("populating _references_by_external_id lookup...")
+        self._references_by_external_id: dict[int | str, Document] = {
+            doc.document_identity.external_id: doc  # type:ignore[union-attr]
+            for doc in tmp_refs
+            if doc.document_identity.external_id is not None  # type:ignore[union-attr]
+        }
+        logger.debug(self._references_by_external_id.keys())
+
         try:
+            logger.debug("populating _references_by_author_year lookup (longest)...")
             self._references_by_author_year_longest: dict[str, Document] = {
                 doc.author_year_from_document_identity(
                     substring_strategy="longest"
@@ -374,6 +387,7 @@ class DocumentReferenceLinker:
             self._references_by_author_year_longest = {}
 
         try:
+            logger.debug("populating _references_by_author_year lookup (last)...")
             self._references_by_author_year_last: dict[str, Document] = {
                 doc.author_year_from_document_identity(substring_strategy="last"): doc
                 for doc in tmp_refs
@@ -422,6 +436,7 @@ class DocumentReferenceLinker:
                 self._get_linkages_filename_author_year, "last"
             ),
             LinkingStrategy.FILENAME_ID: self._get_linkages_filename_id,
+            LinkingStrategy.FILENAME_EXTERNAL_ID: self._get_linkages_filename_external_id,  # noqa:E501
         }
 
         return linking_strategy_map[linking_strategy]
@@ -561,6 +576,51 @@ class DocumentReferenceLinker:
                 unlinked_document=unlinked_doc,
             )
 
+    def _get_linkages_filename_external_id(self) -> Generator[LinkedInterimPayload]:
+        """
+        Yield linkages between files and reference-documents based on
+        assumption that files are named `external_id.pdf`, e.g `ABC123.pdf`.
+
+        This strategy looks up documents using their external_id field instead of
+        the internal document_id field.
+
+        Yields:
+            Generator[LinkedInterimPayload]:
+
+        """
+        if not self.document_base_dir or not self.document_base_dir.is_dir():
+            bad_base_dir = "self.document_base_dir needs to be a valid directory."
+            raise ValueError(bad_base_dir)
+
+        for file in self.document_base_dir.iterdir():
+            if file.suffix not in [".md", ".pdf"]:
+                logger.warning(f"file {file} is not pdf/md. next!")
+                continue
+            try:
+                # Extract ID from filename (everything before the extension)
+                id_guess = file.name.split(".")[0]
+            except ValueError:
+                logger.debug(f"{file.name} isn't convertible to int. next!")
+                continue
+
+            # Try to find document by external ID
+            unlinked_doc = self._references_by_external_id.get(id_guess)
+            if unlinked_doc is None:
+                logger.debug(
+                    f"no reference document found for external id {id_guess}. next!"
+                )
+                continue
+
+            if unlinked_doc.document_identity is None:
+                unlinked_doc.init_document_identity()
+
+            yield LinkedInterimPayload(
+                document_id=unlinked_doc.document_identity.document_id,  # type:ignore[union-attr, arg-type]
+                file_path=file,
+                format=cast("Literal['md', 'pdf']", file.suffix[1:]),
+                unlinked_document=unlinked_doc,
+            )
+
     def guess_file_paths(
         self,
         strategies: list[LinkingStrategy] | None = None,
@@ -579,6 +639,7 @@ class DocumentReferenceLinker:
         """
         default_strategies = [
             LinkingStrategy.FILENAME_ID,
+            LinkingStrategy.FILENAME_EXTERNAL_ID,
             LinkingStrategy.FILENAME_AUTHOR_YEAR_LONGEST,
             LinkingStrategy.FILENAME_AUTHOR_YEAR_LAST,
         ]

--- a/tests/unit/test_documents.py
+++ b/tests/unit/test_documents.py
@@ -68,7 +68,7 @@ def test_document_identity_creation_minimal():
 def test_document_identity_eppi_item_id_valid():
     """Test _eppi_item_id with a valid ID within the allowed digit range."""
     doc_identity = DocumentIdentity(
-        document_id=12345678,
+        external_id=12345678,
         doi=None,
         first_author=None,
         year=None,
@@ -80,7 +80,7 @@ def test_document_identity_eppi_item_id_valid():
 def test_document_identity_eppi_item_id_valid_min_digits():
     """Test _eppi_item_id accepts an ID with the minimum allowed number of digits."""
     doc_identity = DocumentIdentity(
-        document_id=MIN_DOCUMENT_ID,
+        external_id=MIN_DOCUMENT_ID,
         doi=None,
         first_author=None,
         year=None,
@@ -92,7 +92,7 @@ def test_document_identity_eppi_item_id_valid_min_digits():
 def test_document_identity_eppi_item_id_valid_max_digits():
     """Test _eppi_item_id accepts an ID with the maximum allowed number of digits."""
     doc_identity = DocumentIdentity(
-        document_id=MAX_DOCUMENT_ID,
+        external_id=MAX_DOCUMENT_ID,
         doi=None,
         first_author=None,
         year=None,
@@ -214,7 +214,7 @@ def test_document_identity_random_int_id_is_random():
 def test_document_identity_create_id_factory_eppi():
     """Test _create_id_factory returns correct method for eppi item_id present."""
     doc_identity = DocumentIdentity(
-        document_id=12345678,
+        external_id=12345678,
         doi="10.1000/test",
         first_author="Smith",
         year="2024",
@@ -263,7 +263,7 @@ def test_document_identity_create_id_factory_randint():
 def test_document_identity_populate_id_with_eppi():
     """Test populate_id uses EPPI_ITEM_ID when valid."""
     doc_identity = DocumentIdentity(
-        document_id=12345678,
+        external_id=12345678,
         doi="10.1000/test",
         first_author="Smith",
         year="2024",
@@ -435,10 +435,7 @@ def test_document_identity_eppi_id_constraints():
     external_id are correctly set, while invalid EPPi IDs properly fall back to
     other ID generation methods.
     """
-    # Valid EPPi ID (within digit constraints)
-    valid_eppi_id = 12345678  # 8 digits, within range
     doc_identity = DocumentIdentity(
-        document_id=valid_eppi_id,
         external_id="EPP12345678",
         doi=None,
         first_author=None,
@@ -446,11 +443,8 @@ def test_document_identity_eppi_id_constraints():
     )
 
     # Should be accepted and set both internal and external IDs
-    result = doc_identity._eppi_item_id()
-    assert result == valid_eppi_id
-    assert doc_identity.document_id == valid_eppi_id
-    assert doc_identity.internal_id == valid_eppi_id
-    assert doc_identity.external_id == "EPP12345678"
+    with pytest.raises(BadDocumentIdError):
+        doc_identity._eppi_item_id()
 
     # Invalid EPPi ID (too few digits)
     invalid_eppi_id = MIN_DOCUMENT_ID - 1  # Too short

--- a/tests/unit/test_documents.py
+++ b/tests/unit/test_documents.py
@@ -392,6 +392,116 @@ def test_populate_id_uses_different_method_seemingly_identical_records():
     assert doc_identity1.document_id_source != doc_identity2.document_id_source
 
 
+@pytest.mark.parametrize(
+    ("external_id_input", "expected_external_id"),
+    [
+        (12345678, 12345678),  # Integer ID
+        ("ABC123", "ABC123"),  # String ID
+        (None, None),  # None ID
+        ("99999999", "99999999"),  # String representation of number
+    ],
+)
+def test_document_identity_internal_and_external_ids_various_types(
+    external_id_input, expected_external_id
+):
+    """
+    Test that internal_id and external_id fields
+    work correctly with various input types.
+
+    This test verifies that both internal_id
+    and external_id are properly set
+    and maintained when initialising DocumentIdentity
+    objects with different types of external_id values.
+    """
+    # Test basic initialization with different external_id types
+    doc_identity = DocumentIdentity(
+        document_id=12345678,
+        external_id=external_id_input,
+        doi="10.1000/test",
+        first_author="Smith",
+        year="2024",
+    )
+
+    assert doc_identity.document_id == 12345678
+    assert doc_identity.internal_id == 12345678
+    assert doc_identity.external_id == expected_external_id
+
+
+def test_document_identity_eppi_id_constraints():
+    """
+    Test that EPPi ID constraints are properly handled and external_id is preserved.
+
+    This test verifies that valid EPPi IDs are accepted and both internal_id and
+    external_id are correctly set, while invalid EPPi IDs properly fall back to
+    other ID generation methods.
+    """
+    # Valid EPPi ID (within digit constraints)
+    valid_eppi_id = 12345678  # 8 digits, within range
+    doc_identity = DocumentIdentity(
+        document_id=valid_eppi_id,
+        external_id="EPP12345678",
+        doi=None,
+        first_author=None,
+        year=None,
+    )
+
+    # Should be accepted and set both internal and external IDs
+    result = doc_identity._eppi_item_id()
+    assert result == valid_eppi_id
+    assert doc_identity.document_id == valid_eppi_id
+    assert doc_identity.internal_id == valid_eppi_id
+    assert doc_identity.external_id == "EPP12345678"
+
+    # Invalid EPPi ID (too few digits)
+    invalid_eppi_id = MIN_DOCUMENT_ID - 1  # Too short
+    doc_identity2 = DocumentIdentity(
+        document_id=invalid_eppi_id,
+        external_id="INVALID123",
+        doi="10.1000/test",
+        first_author="Smith",
+        year="2024",
+    )
+
+    # Should fall back to other methods, but external_id should still be preserved
+    doc_identity2.populate_id()
+
+    assert doc_identity2.document_id is not None
+    assert doc_identity2.internal_id is not None
+    assert doc_identity2.external_id == "INVALID123"
+    assert (
+        MIN_DOCUMENT_ID_DIGITS
+        <= len(str(doc_identity2.document_id))
+        <= MAX_DOCUMENT_ID_DIGITS
+    )
+
+
+def test_document_identity_integration_with_document():
+    """Test that Document class properly initializes both internal and external IDs."""
+    from destiny_sdk.references import ReferenceFileInput
+
+    citation = ReferenceFileInput(
+        doi="10.1000/test",
+        authors="Smith, John",
+        year="2024",
+    )
+
+    doc = Document(
+        name="Test Document",
+        citation=citation,
+        document_id=99999999,  # This should become external_id
+    )
+
+    # Initialize document identity
+    doc.init_document_identity()
+
+    # Verify the relationship
+    assert doc.document_id == doc.document_identity.document_id
+    assert doc.document_identity.internal_id == doc.document_identity.document_id
+    assert (
+        doc.document_identity.external_id == 99999999
+    )  # Should be preserved from document_id
+
+
 # document tests
 def test_document_creation():
     """Test creating a document."""
@@ -531,7 +641,7 @@ def test_document_is_linked_valid() -> None:
 def test_document_is_final_requires_context():
     """Test that is_final=True requires context."""
     citation = ReferenceFileInput()
-    with pytest.raises(ValueError, match="context.*is empty"):
+    with pytest.raises(ValueError, match=r"context.*is empty"):
         Document(
             name="Test Document",
             citation=citation,

--- a/tests/unit/test_documents.py
+++ b/tests/unit/test_documents.py
@@ -442,7 +442,6 @@ def test_document_identity_eppi_id_constraints():
         year=None,
     )
 
-    # Should be accepted and set both internal and external IDs
     with pytest.raises(BadDocumentIdError):
         doc_identity._eppi_item_id()
 

--- a/tests/unit/test_linker.py
+++ b/tests/unit/test_linker.py
@@ -1,6 +1,7 @@
 """Tests for stuff in the processors/linker.py module."""
 
 import json
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1496,3 +1497,119 @@ def test_guess_file_paths_partial_match(tmp_path):
 
     assert 12345678 in result
     assert 87654321 not in result
+
+
+def test_linker_get_linkages_filename_external_id():
+    """Test _get_linkages_filename_external_id links documents by external ID."""
+    # Create test documents with external IDs
+    doc1 = Document(
+        name="Test Doc 1",
+        citation=ReferenceFileInput(doi="10.1000/test1"),
+        document_id=12345678,  # This becomes internal_id
+    )
+
+    # Manually set external_id
+    doc1.document_identity = DocumentIdentity(
+        document_id=12345678,
+        external_id="EXT12345678",  # This is the external ID we'll match against
+        doi="10.1000/test1",
+        first_author="Smith",
+        year="2024",
+    )
+
+    doc2 = Document(
+        name="Test Doc 2",
+        citation=ReferenceFileInput(doi="10.1000/test2"),
+        document_id=87654321,  # This becomes internal_id
+    )
+
+    # Manually set external_id
+    doc2.document_identity = DocumentIdentity(
+        document_id=87654321,
+        external_id="EXT87654321",  # This is the external ID we'll match against
+        doi="10.1000/test2",
+        first_author="Jones",
+        year="2024",
+    )
+
+    # Create a mock file system with files named after external IDs
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Create files with external IDs in their names
+        pdf_file1 = tmp_path / "EXT12345678.pdf"
+        pdf_file1.write_text("test content 1")
+
+        pdf_file2 = tmp_path / "EXT87654321.pdf"
+        pdf_file2.write_text("test content 2")
+
+        # Create a file that doesn't match any external ID
+        pdf_file3 = tmp_path / "NONMATCHING.pdf"
+        pdf_file3.write_text("test content 3")
+
+        # Mock the linker to use this directory
+        linker = DocumentReferenceLinker(
+            references=[doc1, doc2],
+            document_base_dir=tmp_path,
+        )
+
+        # Test the new external ID linking functionality
+        linkages = list(linker._get_linkages_filename_external_id())
+
+        # Should find 2 linkages (one for each external ID)
+        assert len(linkages) == 2
+
+        # Check that we got the right files
+        file_paths = {str(linkage.file_path) for linkage in linkages}
+        assert str(pdf_file1) in file_paths
+        assert str(pdf_file2) in file_paths
+
+        # Verify that the third file wasn't matched (doesn't have matching external ID)
+        assert str(pdf_file3) not in file_paths
+
+        # Verify that document IDs are correctly returned
+        doc_ids = {linkage.document_id for linkage in linkages}
+        assert 12345678 in doc_ids  # First document's internal ID
+        assert 87654321 in doc_ids  # Second document's internal ID
+
+
+def test_linker_get_linkages_filename_external_id_no_match():
+    """
+    Test _get_linkages_filename_external_id handles files
+    with no matching external IDs.
+    """
+    # Create test documents with external IDs
+    doc1 = Document(
+        name="Test Doc 1",
+        citation=ReferenceFileInput(doi="10.1000/test1"),
+        document_id=12345678,
+    )
+
+    # Manually set external_id
+    doc1.document_identity = DocumentIdentity(
+        document_id=12345678,
+        external_id="EXT12345678",
+        doi="10.1000/test1",
+        first_author="Smith",
+        year="2024",
+    )
+
+    # Create a mock file system with files that don't match external IDs
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        # Create files with non-matching names
+        pdf_file = tmp_path / "DIFFERENT_ID.pdf"
+        pdf_file.write_text("test content")
+
+        # Mock the linker to use this directory
+        linker = DocumentReferenceLinker(
+            references=[doc1],
+            document_base_dir=tmp_path,
+        )
+
+        # Test the new external ID linking functionality
+        linkages = list(linker._get_linkages_filename_external_id())
+
+        # Should find 0 linkages (no matches)
+        assert len(linkages) == 0

--- a/tests/unit/test_processed_gold_standard_annotations.py
+++ b/tests/unit/test_processed_gold_standard_annotations.py
@@ -1,0 +1,238 @@
+"""Tests for processed_gold_standard_annotations module."""
+
+import csv
+import tempfile
+from pathlib import Path
+
+from deet.data_models.base import AttributeType
+from deet.data_models.documents import Document, DocumentIdentity
+from deet.data_models.eppi import (
+    EppiAttribute,
+    EppiDocument,
+    EppiGoldStandardAnnotatedDocument,
+)
+from deet.data_models.processed_gold_standard_annotations import (
+    ProcessedAnnotationData,
+    ProcessedEppiAnnotationData,
+)
+
+
+def test_processed_annotation_data_export_linkage_mapper_csv_basic():
+    """Test basic export_linkage_mapper_csv functionality."""
+    doc1 = Document(
+        name="Test Document 1",
+        citation={"title": "Test Title 1", "authors": ["Author 1"]},
+        document_id=12345678,
+    )
+    doc1.document_identity = DocumentIdentity(
+        document_id=12345678,
+        external_id="EXT123",
+        doi=None,
+        first_author="Author 1",
+        year="2023",
+    )
+
+    doc2 = Document(
+        name="Test Document 2",
+        citation={"title": "Test Title 2", "authors": ["Author 2"]},
+        document_id=87654321,
+    )
+    doc2.document_identity = DocumentIdentity(
+        document_id=87654321,
+        external_id="EXT456",
+        doi=None,
+        first_author="Author 2",
+        year="2023",
+    )
+
+    processed_data = ProcessedAnnotationData(
+        attributes=[],
+        documents=[doc1, doc2],
+        annotations=[],
+        annotated_documents=[],
+        attribute_id_to_label={},
+    )
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        processed_data.export_linkage_mapper_csv(tmp_path)
+        with tmp_path.open("r", newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 2
+
+        row1 = next(row for row in rows if row["document_id"] == "12345678")
+        assert row1["external_id"] == "EXT123"
+        assert row1["name"] == "Test Document 1"
+        assert row1["file_path"] == ""
+
+        row2 = next(row for row in rows if row["document_id"] == "87654321")
+        assert row2["external_id"] == "EXT456"
+        assert row2["name"] == "Test Document 2"
+        assert row2["file_path"] == ""
+
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def test_processed_annotation_data_export_linkage_mapper_csv_no_document_identity():
+    """Test export_linkage_mapper_csv when document identity is not set."""
+    doc1 = Document(
+        name="Test Document 1",
+        citation={"title": "Test Title 1", "authors": ["Author 1"]},
+        document_id=12345678,
+    )
+
+    processed_data = ProcessedAnnotationData(
+        attributes=[],
+        documents=[doc1],
+        annotations=[],
+        annotated_documents=[],
+        attribute_id_to_label={},
+    )
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        processed_data.export_linkage_mapper_csv(tmp_path)
+        with tmp_path.open("r", newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 1
+
+        row = rows[0]
+        assert row["document_id"] == "12345678"
+        assert row["name"] == "Test Document 1"
+        assert row["file_path"] == ""
+
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def test_processed_annotation_data_export_linkage_mapper_csv_no_base_dir():
+    """Test export_linkage_mapper_csv when no base directory is provided."""
+    doc1 = Document(
+        name="Test Document 1",
+        citation={"title": "Test Title 1", "authors": ["Author 1"]},
+        document_id=12345678,
+    )
+    doc1.document_identity = DocumentIdentity(
+        document_id=12345678,
+        external_id="EXT123",
+        doi=None,
+        first_author="Author 1",
+        year="2023",
+    )
+
+    doc2 = Document(
+        name="Test Document 2",
+        citation={"title": "Test Title 2", "authors": ["Author 2"]},
+        document_id=87654321,
+    )
+    doc2.document_identity = DocumentIdentity(
+        document_id=87654321,
+        external_id="EXT456",
+        doi=None,
+        first_author="Author 2",
+        year="2023",
+    )
+
+    processed_data = ProcessedAnnotationData(
+        attributes=[],
+        documents=[doc1, doc2],
+        annotations=[],
+        annotated_documents=[],
+        attribute_id_to_label={},
+    )
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        processed_data.export_linkage_mapper_csv(tmp_path)
+        with tmp_path.open("r", newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 2
+
+        row1 = next(row for row in rows if row["document_id"] == "12345678")
+        assert row1["external_id"] == "EXT123"
+        assert row1["name"] == "Test Document 1"
+        assert row1["file_path"] == ""
+
+        row2 = next(row for row in rows if row["document_id"] == "87654321")
+        assert row2["external_id"] == "EXT456"
+        assert row2["name"] == "Test Document 2"
+        assert row2["file_path"] == ""
+
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def test_processed_eppi_annotation_data_inheritance():
+    """Test that ProcessedEppiAnnotationData inherits correctly."""
+    attribute = EppiAttribute(
+        attribute_id=1,
+        attribute_label="Test Attribute",
+        output_data_type=AttributeType.STRING,
+        prompt="Test prompt",
+        custom_prompt=None,
+    )
+
+    doc = EppiDocument(
+        name="Test Document",
+        citation={"title": "Test Title", "authors": ["Author"]},
+        document_id=12345678,
+    )
+    doc.document_identity = DocumentIdentity(
+        document_id=12345678,
+        external_id="EXT123",
+        doi=None,
+        first_author="Author",
+        year="2023",
+    )
+
+    annotated_doc = EppiGoldStandardAnnotatedDocument(
+        document=doc,
+        annotations=[],
+    )
+
+    processed_data = ProcessedEppiAnnotationData(
+        attributes=[attribute],
+        documents=[doc],
+        annotations=[],
+        annotated_documents=[annotated_doc],
+        attribute_id_to_label={1: "Test Attribute"},
+        raw_data=None,
+    )
+
+    assert processed_data.total_attributes == 1
+    assert processed_data.total_documents == 1
+    assert processed_data.total_annotations == 0
+    assert processed_data.total_annotated_documents == 1
+
+    assert hasattr(processed_data, "export_linkage_mapper_csv")
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as tmp_file:
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        processed_data.export_linkage_mapper_csv(tmp_path)
+        with tmp_path.open("r", newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["document_id"] == "12345678"
+        assert row["external_id"] == "EXT123"
+        assert row["name"] == "Test Document"
+
+    finally:
+        tmp_path.unlink(missing_ok=True)


### PR DESCRIPTION
# Pull Request
This builds on top of the functionality in #251. Also incorporates commit db4b4b886e0fce1ae4b89a5bfcb34de4f142af1f from a different PR. 

tl, dr: implements concepts of `external_id` (i.e. the id that is supplied with the gold standard/reports data, and `internal_id`. `internal_id` mirrors eppi id, but can be adapted. `document_id` is retained, and is the canonical fields, `internal_id` is a symlink to `document_id`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
extensive interactive testing, pytest. 

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
