### PR TITLE
Fix/#269 init document identity eppijson

### DIFF
--- a/deet/processors/eppi_annotation_converter.py
+++ b/deet/processors/eppi_annotation_converter.py
@@ -523,6 +523,7 @@ class EppiAnnotationConverter(AnnotationConverter):
             # Create or retrieve document using ItemId as unique identifier
             if item_id not in documents_by_item_id:
                 document = EppiDocument.model_validate(reference)
+                document.init_document_identity()
                 documents_by_item_id[item_id] = document
             else:
                 document = documents_by_item_id[item_id]


### PR DESCRIPTION
# Pull Request

## Description
Call `init_document_identity()` on document creation in eppijson converter

## Related Issue(s)
Closes #269

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [x] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
Tested with integration test branch - fixes an issue encountered there

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
