### PR TITLE
Support arm-level annotations

### DIFF
--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -327,6 +327,29 @@ ANNOTATION_COERCION_STRATEGIES: dict[
 }
 
 
+class StudyArm(BaseModel):
+    """
+    An arm of a study.
+
+    A study can have multiple arms, with each containing its
+    own set of attributes (e.g. effect size).
+    """
+
+    arm_id: str = Field(
+        ..., description="A unique identifier for this arm within the document"
+    )
+    arm_title: str = Field(..., description="The name of the arm")
+    arm_description: str = Field(..., description="Detailed description of the arm")
+
+
+class StudyArmsDefinitionSchema(BaseModel):
+    """LLM extraction schema for study arms."""
+
+    arms: list[StudyArm] = Field(
+        ..., description="List of all distinct intervention arms found in the text."
+    )
+
+
 class GoldStandardAnnotation(BaseModel):
     """
     A single gold standard annotation for an attribute.
@@ -344,6 +367,14 @@ class GoldStandardAnnotation(BaseModel):
         )
     )
     annotation_type: AnnotationType
+
+    arm_context: StudyArm | None = Field(
+        default=None,
+        description=(
+            "The specific study arm this annotation belongs to."
+            " If None, then it is a study-wide attribute."
+        ),
+    )
     additional_text: str | None = Field(
         description="Notes provided by the annotator - usually the citation "
         " from the paper containing the context window where the attribute is found",
@@ -436,6 +467,14 @@ class LLMAnnotationResponse(BaseModel):
                     attribute_type.to_json_type() for attribute_type in AttributeType
                 ]
             },
+        ),
+    )
+    arm_id: str | None = Field(
+        default=None,
+        description=(
+            "The unique arm_id this annotation applies to. "
+            "Must match of the IDs defined in study_ arms."
+            "Use null for global attributes."
         ),
     )
     additional_text: str | None = Field(

--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -120,6 +120,13 @@ class Attribute(BaseModel):
     output_data_type: AttributeType  # One of the defined output data types
     attribute_id: int  # unique identifier for the attribute
     attribute_label: str  # human-readable way of identifying the attribute
+    is_arm_specific: bool = Field(
+        default=False, description="If true, an arm should be specified for annotations"
+    )
+    is_outcome_specific: bool = Field(
+        default=False,
+        description="If true, an outcome should be specified for annotations",
+    )
 
     def write_to_csv(self, filepath: Path, mode: Literal["a", "w"] = "a") -> None:
         """

--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -327,12 +327,13 @@ ANNOTATION_COERCION_STRATEGIES: dict[
 }
 
 
+# TODO: Add arm characteristics (as enums?) that
+# are held by all arms (e.g. intervention/control)
 class StudyArm(BaseModel):
     """
     An arm of a study.
 
-    A study can have multiple arms, with each containing its
-    own set of attributes (e.g. effect size).
+    A study can have multiple arms, each describing an experimental group.
     """
 
     arm_id: str = Field(
@@ -342,11 +343,38 @@ class StudyArm(BaseModel):
     arm_description: str = Field(..., description="Detailed description of the arm")
 
 
+# TODO: Add outcome characteristics that are
+# held by all outcomes (e.g. primary/secondary)
+class StudyOutcome(BaseModel):
+    """
+    An outcome of a study.
+
+    A study can have multiple outcomes, each of which can be measured across study arms.
+    """
+
+    outcome_id: str = Field(
+        ..., description="A unique identifier for this arm within the document"
+    )
+    outcome_title: str = Field(..., description="The name of the outcome")
+    outcome_description: str = Field(
+        ..., description="Detailed description of the outcome"
+    )
+
+
 class StudyArmsDefinitionSchema(BaseModel):
     """LLM extraction schema for study arms."""
 
     arms: list[StudyArm] = Field(
-        ..., description="List of all distinct intervention arms found in the text."
+        default=[],
+        description="List of all distinct intervention arms found in the text.",
+    )
+
+
+class StudyOutcomesDefinitionSchema(BaseModel):
+    """LLM extraction schema for study outcomes."""
+
+    outcomes: list[StudyOutcome] = Field(
+        default=[], description="List of all distinct outcomes found in the text."
     )
 
 
@@ -372,7 +400,14 @@ class GoldStandardAnnotation(BaseModel):
         default=None,
         description=(
             "The specific study arm this annotation belongs to."
-            " If None, then it is a study-wide attribute."
+            " If None, then it is a study/outcome-wide annotation."
+        ),
+    )
+    outcome_context: StudyOutcome | None = Field(
+        default=None,
+        description=(
+            "The specific outcome this annotation belongs to."
+            " If None, then it is a study/arm-wide annotation"
         ),
     )
     additional_text: str | None = Field(
@@ -473,8 +508,16 @@ class LLMAnnotationResponse(BaseModel):
         default=None,
         description=(
             "The unique arm_id this annotation applies to. "
-            "Must match of the IDs defined in study_ arms."
-            "Use null for global attributes."
+            "Must match of the IDs defined in study_arms."
+            "Use null if not specific to an arm."
+        ),
+    )
+    outcome_id: str | None = Field(
+        default=None,
+        description=(
+            "The unique outcome_id this annotation applies to. "
+            "Must match of the IDs defined in study_outcomes."
+            "Use null if not specific to an outcome."
         ),
     )
     additional_text: str | None = Field(

--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -371,8 +371,8 @@ class StudyOutcome(BaseModel):
 class StudyArmsDefinitionSchema(BaseModel):
     """LLM extraction schema for study arms."""
 
-    arms: list[StudyArm] = Field(
-        default=[],
+    arms: tuple[StudyArm, ...] = Field(
+        default=(),
         description="List of all distinct intervention arms found in the text.",
     )
 
@@ -380,8 +380,8 @@ class StudyArmsDefinitionSchema(BaseModel):
 class StudyOutcomesDefinitionSchema(BaseModel):
     """LLM extraction schema for study outcomes."""
 
-    outcomes: list[StudyOutcome] = Field(
-        default=[], description="List of all distinct outcomes found in the text."
+    outcomes: tuple[StudyOutcome, ...] = Field(
+        default=(), description="List of all distinct outcomes found in the text."
     )
 
 

--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -523,7 +523,7 @@ class GoldStandardAnnotatedDocument(
     annotations: list[GoldStandardAnnotationTypeVar]
 
     def get_attribute_annotation(
-        self, attribute: Attribute, arm_id: str | None
+        self, attribute: Attribute, arm_id: str | None = None
     ) -> GoldStandardAnnotation:
         """Get the value of the annotation of the corresponding attribute."""
         result = None

--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -522,6 +522,8 @@ class GoldStandardAnnotatedDocument(
 
     document: DocumentTypeVar
     annotations: list[GoldStandardAnnotationTypeVar]
+    study_arms: tuple[StudyArm, ...] = ()
+    study_outcomes: tuple[StudyOutcome, ...] = ()
 
     def get_attribute_annotation(
         self,
@@ -573,32 +575,6 @@ class GoldStandardAnnotatedDocument(
             )
 
         return result
-
-    def get_unique_arms(self) -> list[StudyArm | None]:
-        """Extract unique study arms found in annotations for this document."""
-        if not self.annotations:
-            return [None]
-
-        unique_arms_map: dict[str, StudyArm | None] = {
-            ann.arm_context.arm_id
-            if ann.arm_context is not None
-            else "__GLOBAL__": ann.arm_context
-            for ann in self.annotations
-        }
-        return list(unique_arms_map.values())
-
-    def get_unique_outcomes(self) -> list[StudyOutcome | None]:
-        """Extract unique study arms found in annotations for this document."""
-        if not self.annotations:
-            return [None]
-
-        unique_outcomes_map: dict[str, StudyOutcome | None] = {
-            ann.outcome_context.outcome_id
-            if ann.outcome_context is not None
-            else "__GLOBAL__": ann.outcome_context
-            for ann in self.annotations
-        }
-        return list(unique_outcomes_map.values())
 
 
 GoldStandardAnnotatedDocumentTypeVar = TypeVar(

--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -22,6 +22,7 @@ from deet.data_models.base import (
     GoldStandardAnnotation,
     GoldStandardAnnotationTypeVar,
     StudyArm,
+    StudyOutcome,
 )
 from deet.exceptions import (
     BadDocumentIdError,
@@ -523,7 +524,10 @@ class GoldStandardAnnotatedDocument(
     annotations: list[GoldStandardAnnotationTypeVar]
 
     def get_attribute_annotation(
-        self, attribute: Attribute, arm_id: str | None = None
+        self,
+        attribute: Attribute,
+        arm_id: str | None = None,
+        outcome_id: str | None = None,
     ) -> GoldStandardAnnotation:
         """Get the value of the annotation of the corresponding attribute."""
         result = None
@@ -533,7 +537,12 @@ class GoldStandardAnnotatedDocument(
                 annotation_arm_id = (
                     annotation.arm_context.arm_id if annotation.arm_context else None
                 )
-                if annotation_arm_id == arm_id:
+                annotation_outcome_id = (
+                    annotation.outcome_context.outcome_id
+                    if annotation.outcome_context
+                    else None
+                )
+                if annotation_arm_id == arm_id and annotation_outcome_id == outcome_id:
                     if result is not None:
                         multiple_matches = (
                             "More than one annotation found for "
@@ -577,6 +586,19 @@ class GoldStandardAnnotatedDocument(
             for ann in self.annotations
         }
         return list(unique_arms_map.values())
+
+    def get_unique_outcomes(self) -> list[StudyOutcome | None]:
+        """Extract unique study arms found in annotations for this document."""
+        if not self.annotations:
+            return [None]
+
+        unique_outcomes_map: dict[str, StudyOutcome | None] = {
+            ann.outcome_context.outcome_id
+            if ann.outcome_context is not None
+            else "__GLOBAL__": ann.outcome_context
+            for ann in self.annotations
+        }
+        return list(unique_outcomes_map.values())
 
 
 GoldStandardAnnotatedDocumentTypeVar = TypeVar(

--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -21,6 +21,7 @@ from deet.data_models.base import (
     Attribute,
     GoldStandardAnnotation,
     GoldStandardAnnotationTypeVar,
+    StudyArm,
 )
 from deet.exceptions import (
     BadDocumentIdError,
@@ -521,20 +522,27 @@ class GoldStandardAnnotatedDocument(
     document: DocumentTypeVar
     annotations: list[GoldStandardAnnotationTypeVar]
 
-    def get_attribute_annotation(self, attribute: Attribute) -> GoldStandardAnnotation:
+    def get_attribute_annotation(
+        self, attribute: Attribute, arm_id: str | None
+    ) -> GoldStandardAnnotation:
         """Get the value of the annotation of the corresponding attribute."""
         result = None
         output_data: Any
         for annotation in self.annotations:
             if annotation.attribute.attribute_id == attribute.attribute_id:
-                if result is not None:
-                    multiple_matches = (
-                        "More than one annotation found for "
-                        f"attribute: {attribute.attribute_label}. We don't know how to"
-                        "interpret which is the canonical version."
-                    )
-                    raise DuplicateAnnotationError(multiple_matches)
-                result = annotation
+                annotation_arm_id = (
+                    annotation.arm_context.arm_id if annotation.arm_context else None
+                )
+                if annotation_arm_id == arm_id:
+                    if result is not None:
+                        multiple_matches = (
+                            "More than one annotation found for "
+                            f"attribute: {attribute.attribute_label}. "
+                            "We don't know how to"
+                            "interpret which is the canonical version."
+                        )
+                        raise DuplicateAnnotationError(multiple_matches)
+                    result = annotation
 
         if result is None:
             try:
@@ -556,6 +564,19 @@ class GoldStandardAnnotatedDocument(
             )
 
         return result
+
+    def get_unique_arms(self) -> list[StudyArm | None]:
+        """Extract unique study arms found in annotations for this document."""
+        if not self.annotations:
+            return [None]
+
+        unique_arms_map: dict[str, StudyArm | None] = {
+            ann.arm_context.arm_id
+            if ann.arm_context is not None
+            else "__GLOBAL__": ann.arm_context
+            for ann in self.annotations
+        }
+        return list(unique_arms_map.values())
 
 
 GoldStandardAnnotatedDocumentTypeVar = TypeVar(

--- a/deet/data_models/processed_gold_standard_annotations.py
+++ b/deet/data_models/processed_gold_standard_annotations.py
@@ -141,6 +141,10 @@ class ProcessedAttributeData(BaseModel, Generic[AttributeTypeVar]):
             matching_attribute.populate_prompt_from_dict(row, overwrite=overwrite)
             csv_attr_type = AttributeType(row.get("output_data_type"))  # type:ignore[arg-type]
             matching_attribute.output_data_type = csv_attr_type
+            matching_attribute.is_arm_specific = row.get("is_arm_specific", False)
+            matching_attribute.is_outcome_specific = row.get(
+                "is_outcome_specific", False
+            )
 
         except ValueError as e:
             logger.error(

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -16,7 +16,7 @@ from rapidfuzz import fuzz
 from rich.console import Console
 from rich.table import Table
 
-from deet.data_models.base import AttributeTypeVar
+from deet.data_models.base import AttributeTypeVar, StudyArm
 from deet.data_models.documents import (
     GoldStandardAnnotatedDocumentList,
     GoldStandardAnnotatedDocumentTypeVar,
@@ -146,6 +146,26 @@ class GoldStandardLLMEvaluator:
         if custom_metrics is not None:
             self.add_custom_metrics(custom_metrics)
 
+    def _get_distinct_arms(
+        self,
+        gold_doc: GoldStandardAnnotatedDocumentTypeVar,
+        llm_doc: GoldStandardAnnotatedDocumentTypeVar | None,
+    ) -> list[StudyArm | None]:
+        """
+        Collect unique arms across LLM and human annotated documents.
+
+        # TODO: fuzzily match arms, humans and LLMs won't use the same IDs!
+        """
+        gold_arms = gold_doc.get_unique_arms()
+        llm_arms = llm_doc.get_unique_arms() if llm_doc else [None]
+
+        distinct_arms_map: dict[str, StudyArm | None] = {}
+        for arm in gold_arms + llm_arms:
+            key = arm.arm_id if arm is not None else "__GLOBAL__"
+            distinct_arms_map[key] = arm
+
+        return list(distinct_arms_map.values())
+
     def add_custom_metrics(self, custom_metrics: list[str]) -> None:
         """Add custom metrics. These must be valid metrics from sklearn.metrics."""
         for custom_metric_name in custom_metrics:
@@ -183,27 +203,42 @@ class GoldStandardLLMEvaluator:
             y_pred: list[Any] = []
             for document in self.gold_standard_annotated_documents:
                 doc_id = document.document.safe_identity.document_id
-                logger.debug(
-                    f"Extracting gold standard and LLM prediction for doc {doc_id}"
-                )
-                gs_val = document.get_attribute_annotation(attribute).output_data
-                y_true.append(gs_val)
 
                 try:
                     llm_doc = self.llm_annotated_documents.get_by_id(doc_id)
                 except MissingDocumentError:
-                    y_pred.append(None)
+                    llm_doc = None
                     logger.warning(f"LLM annotated doc not found - ID: {doc_id}")
-                    continue
-                try:
-                    llm_val = llm_doc.get_attribute_annotation(attribute).output_data
-                except DuplicateAnnotationError:
-                    llm_val = None
-                    logger.warning(
-                        f"LLM produced multiple annotations for a single"
-                        f" attribute with doc: {doc_id}"
-                    )
-                y_pred.append(llm_val)
+
+                logger.debug(
+                    f"Extracting gold standard and LLM prediction for doc {doc_id}"
+                )
+
+                distinct_arms = self._get_distinct_arms(document, llm_doc)
+
+                for arm in distinct_arms:
+                    arm_id = arm.arm_id if arm else None
+                    gs_ann = document.get_attribute_annotation(attribute, arm_id)
+                    gs_val = gs_ann.output_data if gs_ann else None
+                    y_true.append(gs_val)
+
+                    if llm_doc is None:
+                        y_pred.append(None)
+                    else:
+                        try:
+                            llm_ann = llm_doc.get_attribute_annotation(
+                                attribute, arm_id=arm_id
+                            )
+                            llm_val = llm_ann.output_data if llm_ann else None
+                        except DuplicateAnnotationError:
+                            llm_val = None
+                            logger.warning(
+                                f"LLM produced multiple annotations for attribute "
+                                f"{attribute.attribute_id} for arm "
+                                f"'{getattr(arm, 'arm_id', '__GLOBAL__')}' "
+                                f"in doc: {doc_id}"
+                            )
+                        y_pred.append(llm_val)
 
             applicable_metrics = get_metrics_for_attribute_type(
                 attribute.output_data_type
@@ -306,6 +341,8 @@ class GoldStandardLLMEvaluator:
                 fieldnames=[
                     "document_id",
                     "document_name",
+                    "arm_id",
+                    "arm_title",
                     "attribute_id",
                     "attribute_label",
                     "attribute_presence",
@@ -322,13 +359,14 @@ class GoldStandardLLMEvaluator:
             )
             writer.writeheader()
             for doc in self.gold_standard_annotated_documents:
+                doc_id = doc.document.safe_identity.document_id
                 try:
-                    llm_annotated_doc = self.llm_annotated_documents.get_by_id(
-                        doc.document.safe_identity.document_id
-                    )
+                    llm_annotated_doc = self.llm_annotated_documents.get_by_id(doc_id)
                 except MissingDocumentError:
                     llm_annotated_doc = None
+                    logger.warning(f"LLM annotated doc not found - ID: {doc_id}")
 
+                distinct_arms = self._get_distinct_arms(doc, llm_annotated_doc)
                 context: str | None = (
                     None
                     if llm_annotated_doc is None
@@ -336,71 +374,72 @@ class GoldStandardLLMEvaluator:
                 )
 
                 for attribute in self.attributes:
-                    human_ann = doc.get_attribute_annotation(attribute)
-                    gold_real = next(
-                        (
-                            ann
-                            for ann in doc.annotations
-                            if ann.attribute.attribute_id == attribute.attribute_id
-                        ),
-                        None,
-                    )
-                    if gold_real is not None:
-                        human_additional_text: str = gold_real.additional_text or ""
-                        item_attr_full: str = _eppi_full_text_details_colon_separated(
-                            gold_real
-                        )
-                    else:
-                        human_additional_text = ""
-                        item_attr_full = ""
-                    present = gold_real is not None
-                    human_fuzzy = _verbatim_fuzzy_match_pct(
-                        human_additional_text, context
-                    )
+                    for arm in distinct_arms:
+                        arm_id = arm.arm_id if arm else None
+                        gold_real = doc.get_attribute_annotation(attribute, arm_id)
 
-                    llm_extraction: Any = None
-                    llm_reasoning: str | None = None
-                    llm_verbatim: str | None = None
-                    llm_fuzzy = 0.0
-
-                    if llm_annotated_doc is None:
-                        llm_reasoning = (
-                            "LLM did not produce an output for this document."
-                            " Check the logs carefully to find out why"
-                        )
-                    else:
-                        try:
-                            llm_annotation = llm_annotated_doc.get_attribute_annotation(
-                                attribute
+                        if gold_real is not None:
+                            human_additional_text: str = gold_real.additional_text or ""
+                            item_attr_full: str = (
+                                _eppi_full_text_details_colon_separated(gold_real)
                             )
-                            llm_extraction = llm_annotation.output_data
-                            llm_reasoning = llm_annotation.reasoning
-                            llm_verbatim = llm_annotation.additional_text
-                            llm_fuzzy = _verbatim_fuzzy_match_pct(llm_verbatim, context)
-                        except DuplicateAnnotationError:
+                        else:
+                            human_additional_text = ""
+                            item_attr_full = ""
+                        present = gold_real is not None
+                        human_fuzzy = _verbatim_fuzzy_match_pct(
+                            human_additional_text, context
+                        )
+
+                        llm_extraction: Any = None
+                        llm_reasoning: str | None = None
+                        llm_verbatim: str | None = None
+                        llm_fuzzy = 0.0
+
+                        if llm_annotated_doc is None:
                             llm_reasoning = (
-                                "The LLM produced multiple annotations"
-                                "for this single attribute"
+                                "LLM did not produce an output for this document."
+                                " Check the logs carefully to find out why"
                             )
+                        else:
+                            try:
+                                llm_annotation = (
+                                    llm_annotated_doc.get_attribute_annotation(
+                                        attribute, arm_id
+                                    )
+                                )
+                                llm_extraction = llm_annotation.output_data
+                                llm_reasoning = llm_annotation.reasoning
+                                llm_verbatim = llm_annotation.additional_text
+                                llm_fuzzy = _verbatim_fuzzy_match_pct(
+                                    llm_verbatim, context
+                                )
+                            except DuplicateAnnotationError:
+                                llm_reasoning = (
+                                    "The LLM produced multiple annotations"
+                                    "for this single attribute"
+                                )
 
-                    writer.writerow(
-                        {
-                            "document_id": doc.document.safe_identity.document_id,
-                            "document_name": doc.document.name,
-                            "attribute_id": attribute.attribute_id,
-                            "attribute_label": attribute.attribute_label,
-                            "attribute_presence": str(present),
-                            "human_additional_text": human_additional_text,
-                            "item_attribute_full_text_details": item_attr_full,
-                            "human_extraction": human_ann.output_data,
-                            "llm_extraction": llm_extraction,
-                            "llm_reasoning": llm_reasoning,
-                            "llm_verbatim_text": llm_verbatim,
-                            "human_verbatim_fuzzy_match_pct": f"{human_fuzzy:.2f}",
-                            "llm_verbatim_fuzzy_match_pct": f"{llm_fuzzy:.2f}",
-                            "extraction_run_id": self.extraction_run_id,
-                        }
-                    )
+                        writer.writerow(
+                            {
+                                "document_id": doc.document.safe_identity.document_id,
+                                "document_name": doc.document.name,
+                                "arm_id": arm.arm_id if arm else "study-wide",
+                                "arm_title": arm.arm_title if arm else "study-wide",
+                                "attribute_id": attribute.attribute_id,
+                                "attribute_label": attribute.attribute_label,
+                                "attribute_presence": str(present),
+                                "human_additional_text": human_additional_text,
+                                "item_attribute_full_text_details": item_attr_full,
+                                "human_extraction": gold_real.output_data,
+                                "llm_extraction": llm_extraction,
+                                "llm_reasoning": llm_reasoning,
+                                "llm_verbatim_text": llm_verbatim,
+                                "human_verbatim_fuzzy_match_pct": f"{human_fuzzy:.2f}",
+                                "llm_verbatim_fuzzy_match_pct": f"{llm_fuzzy:.2f}",
+                                "extraction_run_id": self.extraction_run_id,
+                            }
+                        )
 
     def export_llm_csv(self, filepath: Path) -> None:
         """Write the LLM output to csv."""

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -4,6 +4,7 @@ data extracted by hand.
 """
 
 import csv
+import itertools
 import re
 from collections.abc import Sequence
 from itertools import groupby
@@ -16,7 +17,7 @@ from rapidfuzz import fuzz
 from rich.console import Console
 from rich.table import Table
 
-from deet.data_models.base import AttributeTypeVar, StudyArm
+from deet.data_models.base import AttributeTypeVar, StudyArm, StudyOutcome
 from deet.data_models.documents import (
     GoldStandardAnnotatedDocumentList,
     GoldStandardAnnotatedDocumentTypeVar,
@@ -151,20 +152,34 @@ class GoldStandardLLMEvaluator:
         gold_doc: GoldStandardAnnotatedDocumentTypeVar,
         llm_doc: GoldStandardAnnotatedDocumentTypeVar | None,
     ) -> list[StudyArm | None]:
-        """
-        Collect unique arms across LLM and human annotated documents.
-
-        # TODO: fuzzily match arms, humans and LLMs won't use the same IDs!
-        """
+        """Collect unique arms across LLM and human annotated documents."""
         gold_arms = gold_doc.get_unique_arms()
         llm_arms = llm_doc.get_unique_arms() if llm_doc else [None]
 
+        # TODO: fuzzily match outcomes, humans and LLMs won't use the same IDs!
         distinct_arms_map: dict[str, StudyArm | None] = {}
         for arm in gold_arms + llm_arms:
             key = arm.arm_id if arm is not None else "__GLOBAL__"
             distinct_arms_map[key] = arm
 
         return list(distinct_arms_map.values())
+
+    def _get_distinct_outcomes(
+        self,
+        gold_doc: GoldStandardAnnotatedDocumentTypeVar,
+        llm_doc: GoldStandardAnnotatedDocumentTypeVar | None,
+    ) -> list[StudyOutcome | None]:
+        """Collect unique arms across LLM and human annotated documents."""
+        gold_outcomes = gold_doc.get_unique_outcomes()
+        llm_outcomes = llm_doc.get_unique_outcomes() if llm_doc else [None]
+
+        # TODO: fuzzily match outcomes, humans and LLMs won't use the same IDs!
+        distinct_outcomes_map: dict[str, StudyOutcome | None] = {}
+        for outcome in gold_outcomes + llm_outcomes:
+            key = outcome.outcome_id if outcome is not None else "__GLOBAL__"
+            distinct_outcomes_map[key] = outcome
+
+        return list(distinct_outcomes_map.values())
 
     def add_custom_metrics(self, custom_metrics: list[str]) -> None:
         """Add custom metrics. These must be valid metrics from sklearn.metrics."""
@@ -215,30 +230,36 @@ class GoldStandardLLMEvaluator:
                 )
 
                 distinct_arms = self._get_distinct_arms(document, llm_doc)
+                distinct_outcomes = self._get_distinct_outcomes(document, llm_doc)
 
                 for arm in distinct_arms:
-                    arm_id = arm.arm_id if arm else None
-                    gs_ann = document.get_attribute_annotation(attribute, arm_id)
-                    gs_val = gs_ann.output_data if gs_ann else None
-                    y_true.append(gs_val)
+                    for outcome in distinct_outcomes:
+                        arm_id = arm.arm_id if arm else None
+                        outcome_id = outcome.outcome_id if outcome else None
 
-                    if llm_doc is None:
-                        y_pred.append(None)
-                    else:
-                        try:
-                            llm_ann = llm_doc.get_attribute_annotation(
-                                attribute, arm_id=arm_id
-                            )
-                            llm_val = llm_ann.output_data if llm_ann else None
-                        except DuplicateAnnotationError:
-                            llm_val = None
-                            logger.warning(
-                                f"LLM produced multiple annotations for attribute "
-                                f"{attribute.attribute_id} for arm "
-                                f"'{getattr(arm, 'arm_id', '__GLOBAL__')}' "
-                                f"in doc: {doc_id}"
-                            )
-                        y_pred.append(llm_val)
+                        gs_ann = document.get_attribute_annotation(
+                            attribute=attribute, arm_id=arm_id, outcome_id=outcome_id
+                        )
+                        gs_val = gs_ann.output_data if gs_ann else None
+                        y_true.append(gs_val)
+
+                        if llm_doc is None:
+                            y_pred.append(None)
+                        else:
+                            try:
+                                llm_ann = llm_doc.get_attribute_annotation(
+                                    attribute, arm_id=arm_id
+                                )
+                                llm_val = llm_ann.output_data if llm_ann else None
+                            except DuplicateAnnotationError:
+                                llm_val = None
+                                logger.warning(
+                                    f"LLM produced multiple annotations for attribute "
+                                    f"{attribute.attribute_id} for arm "
+                                    f"'{getattr(arm, 'arm_id', '__GLOBAL__')}' "
+                                    f"in doc: {doc_id}"
+                                )
+                            y_pred.append(llm_val)
 
             applicable_metrics = get_metrics_for_attribute_type(
                 attribute.output_data_type
@@ -343,6 +364,8 @@ class GoldStandardLLMEvaluator:
                     "document_name",
                     "arm_id",
                     "arm_title",
+                    "outcome_id",
+                    "outcome_title",
                     "attribute_id",
                     "attribute_label",
                     "attribute_presence",
@@ -367,79 +390,85 @@ class GoldStandardLLMEvaluator:
                     logger.warning(f"LLM annotated doc not found - ID: {doc_id}")
 
                 distinct_arms = self._get_distinct_arms(doc, llm_annotated_doc)
+                distinct_outcomes = self._get_distinct_outcomes(doc, llm_annotated_doc)
+
                 context: str | None = (
                     None
                     if llm_annotated_doc is None
                     else (str(t) if (t := llm_annotated_doc.document.context) else None)
                 )
 
-                for attribute in self.attributes:
-                    for arm in distinct_arms:
-                        arm_id = arm.arm_id if arm else None
-                        gold_real = doc.get_attribute_annotation(attribute, arm_id)
+                for attribute, arm, outcome in itertools.product(
+                    self.attributes, distinct_arms, distinct_outcomes
+                ):
+                    arm_id = arm.arm_id if arm else None
+                    outcome_id = outcome.outcome_id if outcome else None
+                    gold_real = doc.get_attribute_annotation(
+                        attribute=attribute,
+                        arm_id=arm_id,
+                        outcome_id=outcome_id,
+                    )
 
-                        if gold_real is not None:
-                            human_additional_text: str = gold_real.additional_text or ""
-                            item_attr_full: str = (
-                                _eppi_full_text_details_colon_separated(gold_real)
-                            )
-                        else:
-                            human_additional_text = ""
-                            item_attr_full = ""
-                        present = gold_real is not None
-                        human_fuzzy = _verbatim_fuzzy_match_pct(
-                            human_additional_text, context
+                    if gold_real is not None:
+                        human_additional_text: str = gold_real.additional_text or ""
+                        item_attr_full: str = _eppi_full_text_details_colon_separated(
+                            gold_real
                         )
+                    else:
+                        human_additional_text = ""
+                        item_attr_full = ""
+                    present = gold_real is not None
+                    human_fuzzy = _verbatim_fuzzy_match_pct(
+                        human_additional_text, context
+                    )
 
-                        llm_extraction: Any = None
-                        llm_reasoning: str | None = None
-                        llm_verbatim: str | None = None
-                        llm_fuzzy = 0.0
+                    llm_extraction: Any = None
+                    llm_reasoning: str | None = None
+                    llm_verbatim: str | None = None
+                    llm_fuzzy = 0.0
 
-                        if llm_annotated_doc is None:
+                    if llm_annotated_doc is None:
+                        llm_reasoning = (
+                            "LLM did not produce an output for this document."
+                            " Check the logs carefully to find out why"
+                        )
+                    else:
+                        try:
+                            llm_annotation = llm_annotated_doc.get_attribute_annotation(
+                                attribute, arm_id
+                            )
+                            llm_extraction = llm_annotation.output_data
+                            llm_reasoning = llm_annotation.reasoning
+                            llm_verbatim = llm_annotation.additional_text
+                            llm_fuzzy = _verbatim_fuzzy_match_pct(llm_verbatim, context)
+                        except DuplicateAnnotationError:
                             llm_reasoning = (
-                                "LLM did not produce an output for this document."
-                                " Check the logs carefully to find out why"
+                                "The LLM produced multiple annotations"
+                                "for this single attribute"
                             )
-                        else:
-                            try:
-                                llm_annotation = (
-                                    llm_annotated_doc.get_attribute_annotation(
-                                        attribute, arm_id
-                                    )
-                                )
-                                llm_extraction = llm_annotation.output_data
-                                llm_reasoning = llm_annotation.reasoning
-                                llm_verbatim = llm_annotation.additional_text
-                                llm_fuzzy = _verbatim_fuzzy_match_pct(
-                                    llm_verbatim, context
-                                )
-                            except DuplicateAnnotationError:
-                                llm_reasoning = (
-                                    "The LLM produced multiple annotations"
-                                    "for this single attribute"
-                                )
 
-                        writer.writerow(
-                            {
-                                "document_id": doc.document.safe_identity.document_id,
-                                "document_name": doc.document.name,
-                                "arm_id": arm.arm_id if arm else "study-wide",
-                                "arm_title": arm.arm_title if arm else "study-wide",
-                                "attribute_id": attribute.attribute_id,
-                                "attribute_label": attribute.attribute_label,
-                                "attribute_presence": str(present),
-                                "human_additional_text": human_additional_text,
-                                "item_attribute_full_text_details": item_attr_full,
-                                "human_extraction": gold_real.output_data,
-                                "llm_extraction": llm_extraction,
-                                "llm_reasoning": llm_reasoning,
-                                "llm_verbatim_text": llm_verbatim,
-                                "human_verbatim_fuzzy_match_pct": f"{human_fuzzy:.2f}",
-                                "llm_verbatim_fuzzy_match_pct": f"{llm_fuzzy:.2f}",
-                                "extraction_run_id": self.extraction_run_id,
-                            }
-                        )
+                    writer.writerow(
+                        {
+                            "document_id": doc.document.safe_identity.document_id,
+                            "document_name": doc.document.name,
+                            "arm_id": arm.arm_id if arm else "",
+                            "arm_title": arm.arm_title if arm else "",
+                            "outcome_id": outcome.outcome_id if outcome else "",
+                            "outcome_title": outcome.outcome_title if outcome else "",
+                            "attribute_id": attribute.attribute_id,
+                            "attribute_label": attribute.attribute_label,
+                            "attribute_presence": str(present),
+                            "human_additional_text": human_additional_text,
+                            "item_attribute_full_text_details": item_attr_full,
+                            "human_extraction": gold_real.output_data,
+                            "llm_extraction": llm_extraction,
+                            "llm_reasoning": llm_reasoning,
+                            "llm_verbatim_text": llm_verbatim,
+                            "human_verbatim_fuzzy_match_pct": f"{human_fuzzy:.2f}",
+                            "llm_verbatim_fuzzy_match_pct": f"{llm_fuzzy:.2f}",
+                            "extraction_run_id": self.extraction_run_id,
+                        }
+                    )
 
     def export_llm_csv(self, filepath: Path) -> None:
         """Write the LLM output to csv."""
@@ -488,6 +517,5 @@ class GoldStandardLLMEvaluator:
                             "llm_extraction": llm_extraction,
                             "llm_reasoning": llm_reasoning,
                             "llm_verbatim_text": llm_verbatim,
-                            "extraction_run_id": self.extraction_run_id,
                         }
                     )

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -149,11 +149,11 @@ class GoldStandardLLMEvaluator:
 
     def _get_distinct_arms(
         self,
-        gold_doc: GoldStandardAnnotatedDocumentTypeVar,
+        gold_doc: GoldStandardAnnotatedDocumentTypeVar | None,
         llm_doc: GoldStandardAnnotatedDocumentTypeVar | None,
     ) -> list[StudyArm | None]:
         """Collect unique arms across LLM and human annotated documents."""
-        gold_arms = gold_doc.study_arms
+        gold_arms = gold_doc.study_arms if gold_doc else ()
         llm_arms = llm_doc.study_arms if llm_doc else ()
 
         # TODO: fuzzily match outcomes, humans and LLMs won't use the same IDs!
@@ -169,11 +169,11 @@ class GoldStandardLLMEvaluator:
 
     def _get_distinct_outcomes(
         self,
-        gold_doc: GoldStandardAnnotatedDocumentTypeVar,
+        gold_doc: GoldStandardAnnotatedDocumentTypeVar | None,
         llm_doc: GoldStandardAnnotatedDocumentTypeVar | None,
     ) -> list[StudyOutcome | None]:
         """Collect unique arms across LLM and human annotated documents."""
-        gold_outcomes = gold_doc.study_outcomes
+        gold_outcomes = gold_doc.study_outcomes if gold_doc else ()
         llm_outcomes = llm_doc.study_outcomes if llm_doc else ()
 
         # TODO: fuzzily match outcomes, humans and LLMs won't use the same IDs!
@@ -496,10 +496,17 @@ class GoldStandardLLMEvaluator:
             for (
                 llm_annotated_doc
             ) in self.llm_annotated_documents.gold_standard_annotations:
-                for attribute in self.attributes:
+                distinct_arms = self._get_distinct_arms(None, llm_annotated_doc)
+                distinct_outcomes = self._get_distinct_outcomes(None, llm_annotated_doc)
+
+                for attribute, arm, outcome in itertools.product(
+                    self.attributes, distinct_arms, distinct_outcomes
+                ):
+                    arm_id = arm.arm_id if arm else None
+                    outcome_id = outcome.outcome_id if outcome else None
                     try:
                         llm_annotation = llm_annotated_doc.get_attribute_annotation(
-                            attribute
+                            attribute=attribute, arm_id=arm_id, outcome_id=outcome_id
                         )
                         llm_extraction = llm_annotation.output_data
                         llm_reasoning = llm_annotation.reasoning
@@ -518,6 +525,10 @@ class GoldStandardLLMEvaluator:
                         {
                             "document_id": document.safe_identity.document_id,
                             "document_name": document.name,
+                            "arm_id": arm.arm_id if arm else "",
+                            "arm_title": arm.arm_title if arm else "",
+                            "outcome_id": outcome.outcome_id if outcome else "",
+                            "outcome_title": outcome.outcome_title if outcome else "",
                             "attribute_id": attribute.attribute_id,
                             "attribute_label": attribute.attribute_label,
                             "llm_extraction": llm_extraction,

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -153,14 +153,17 @@ class GoldStandardLLMEvaluator:
         llm_doc: GoldStandardAnnotatedDocumentTypeVar | None,
     ) -> list[StudyArm | None]:
         """Collect unique arms across LLM and human annotated documents."""
-        gold_arms = gold_doc.get_unique_arms()
-        llm_arms = llm_doc.get_unique_arms() if llm_doc else [None]
+        gold_arms = gold_doc.study_arms
+        llm_arms = llm_doc.study_arms if llm_doc else ()
 
         # TODO: fuzzily match outcomes, humans and LLMs won't use the same IDs!
         distinct_arms_map: dict[str, StudyArm | None] = {}
         for arm in gold_arms + llm_arms:
             key = arm.arm_id if arm is not None else "__GLOBAL__"
             distinct_arms_map[key] = arm
+
+        if not distinct_arms_map:
+            return [None]
 
         return list(distinct_arms_map.values())
 
@@ -170,14 +173,17 @@ class GoldStandardLLMEvaluator:
         llm_doc: GoldStandardAnnotatedDocumentTypeVar | None,
     ) -> list[StudyOutcome | None]:
         """Collect unique arms across LLM and human annotated documents."""
-        gold_outcomes = gold_doc.get_unique_outcomes()
-        llm_outcomes = llm_doc.get_unique_outcomes() if llm_doc else [None]
+        gold_outcomes = gold_doc.study_outcomes
+        llm_outcomes = llm_doc.study_outcomes if llm_doc else ()
 
         # TODO: fuzzily match outcomes, humans and LLMs won't use the same IDs!
         distinct_outcomes_map: dict[str, StudyOutcome | None] = {}
         for outcome in gold_outcomes + llm_outcomes:
             key = outcome.outcome_id if outcome is not None else "__GLOBAL__"
             distinct_outcomes_map[key] = outcome
+
+        if not distinct_outcomes_map:
+            return [None]
 
         return list(distinct_outcomes_map.values())
 

--- a/deet/extractors/llm_data_extractor.py
+++ b/deet/extractors/llm_data_extractor.py
@@ -23,6 +23,8 @@ from deet.data_models.base import (
     GoldStandardAnnotation,
     LLMInputSchema,
     LLMResponseSchema,
+    StudyArm,
+    StudyArmsDefinitionSchema,
 )
 from deet.data_models.documents import (
     ContextType,
@@ -268,10 +270,62 @@ class LLMDataExtractor:
                 self.custom_system_prompt_file.read_text()
             )
 
-    def extract_from_document(
+    def extract_arms_from_document(self, payload: str) -> Sequence[StudyArm]:
+        """Extract arms from a document."""
+        logger.info("Extracting study arms")
+
+        arm_prompt = (
+            f"Analyse the following document and identify all distinct study arms.\n"
+            f"Context:\n{payload}"
+        )
+
+        arm_system_prompt = (
+            "You are an expert systematic review data extraction assistant."
+            "Your task is to identify and catalogue the distinct study "
+            "arms in the text."
+            "Provide a short snake_case 'arm_id' for each, a clear title, "
+            "and a brief description."
+        )
+
+        messages = [
+            {"role": "system", "content": arm_system_prompt},
+            {"role": "user", "content": arm_prompt},
+        ]
+
+        self._enforce_context_limit(messages, arm_prompt, arm_system_prompt)
+
+        response = litellm.completion(
+            model=self.model,
+            api_key=self.llm_api_key,
+            api_base=self.api_base,
+            messages=messages,
+            temperature=self.config.temperature,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "study_arms_definition_response",
+                    "schema": StudyArmsDefinitionSchema.model_json_schema(),
+                },
+            },
+        )
+
+        response_content = response.choices[0].message.content
+
+        try:
+            validated_arms = StudyArmsDefinitionSchema.model_validate_json(
+                response_content
+            )
+        except ValidationError as e:
+            logger.warning(f"LLM did not return valid arms: {e}")
+            return []
+        logger.info(f"Arm extraction successful. Found {len(validated_arms.arms)} arms")
+        return validated_arms.arms
+
+    def extract_from_document(  # noqa: PLR0913
         self,
         attributes: list[Attribute],
         filter_attribute_ids: list[int] | None = None,
+        study_arms: Sequence[StudyArm] = [],
         *,
         payload: str | None = None,
         md_path: Path | None = None,
@@ -333,13 +387,15 @@ class LLMDataExtractor:
 
         context = self._prepare_context(payload=payload, context_type=context_type)
         prompt = self._generate_user_message_json(
-            payload=context, attributes=selected_attributes
+            payload=context, attributes=selected_attributes, study_arms=study_arms
         )
         llm_response, messages, output_tokens, input_tokens = self._call_llm(
             prompt=prompt
         )
         annotations = self._parse_llm_response(
-            response_content=llm_response, attributes=selected_attributes
+            response_content=llm_response,
+            attributes=selected_attributes,
+            study_arms=study_arms,
         )
 
         return DocumentExtractionResult(
@@ -403,11 +459,16 @@ class LLMDataExtractor:
                     document.context = document.safe_parsed_document.text
 
                 try:
+                    study_arms = self.extract_arms_from_document(
+                        payload=document.context
+                    )
+
                     result = self.extract_from_document(
                         attributes=attributes,
                         filter_attribute_ids=filter_attribute_ids,
                         payload=document.context,
                         context_type=context_type,
+                        study_arms=study_arms,
                     )
 
                     llm_annotated_docs.append(
@@ -534,9 +595,7 @@ class LLMDataExtractor:
         return context
 
     def _generate_user_message_json(
-        self,
-        payload: str,
-        attributes: list[Attribute],
+        self, payload: str, attributes: list[Attribute], study_arms: Sequence[StudyArm]
     ) -> str:
         """
         Generate structured JSON input for the LLM user message.
@@ -566,8 +625,11 @@ class LLMDataExtractor:
             llm_input_attr = LLMInputSchema(**attr_dict)
             attributes_payload.append(llm_input_attr.model_dump())
 
+        arms_payload = [arm.model_dump() for arm in study_arms]
+
         unserialised_prompt = {
             "context": payload,
+            "study_arms": arms_payload,
             "attributes": attributes_payload,
         }
 
@@ -625,12 +687,18 @@ class LLMDataExtractor:
             prompt_data = json.loads(prompt)
             context = prompt_data.get("context", "")
             attributes_payload = prompt_data.get("attributes", [])
-            attributes_part = json.dumps(
-                {"context": "", "attributes": attributes_payload},
+            arms_payload = prompt_data.get("study_arms", [])
+
+            overhead_part = json.dumps(
+                {
+                    "context": "",
+                    "attributes": attributes_payload,
+                    "study_arms": arms_payload,
+                },
                 ensure_ascii=False,
             )
             system_tokens = count_tokens(self.model, str(system_prompt))
-            attributes_tokens = count_tokens(self.model, attributes_part)
+            attributes_tokens = count_tokens(self.model, overhead_part)
             # Buffer for token-count discrepancies or extra tokens from
             # serialization/whitespace that LLM APIs may add.
             buffer = 50
@@ -735,6 +803,7 @@ class LLMDataExtractor:
         self,
         response_content: str,
         attributes: list[Attribute],
+        study_arms: Sequence[StudyArm],
     ) -> list[GoldStandardAnnotation]:
         """
         Parse and validate LLM response against GoldStandardAnnotation structure.
@@ -742,6 +811,7 @@ class LLMDataExtractor:
         Args:
             response_content: Raw JSON string response from LLM
             attributes: List of attributes to match against
+            study_arms: List of study arms to match against
 
         Returns:
             List of GoldStandardAnnotation objects
@@ -784,6 +854,23 @@ class LLMDataExtractor:
                 )
                 continue
 
+            matched_arm = None
+            if llm_annotation.arm_id is not None:
+                matched_arm = next(
+                    (
+                        study_arm
+                        for study_arm in study_arms
+                        if study_arm.arm_id == llm_annotation.arm_id
+                    ),
+                    None,
+                )
+                if not matched_arm:
+                    logger.warning(
+                        f"LLM returned arm_id '{llm_annotation.arm_id}' for attribute "
+                        f"{attribute.attribute_id}, but it doesn't match any"
+                        f"of the extracted arms. Defaulting arm_context to None."
+                    )
+
             additional_text = (
                 llm_annotation.additional_text
                 if self.config.include_additional_text
@@ -795,6 +882,7 @@ class LLMDataExtractor:
             # Convert to full EppiGoldStandardAnnotation
             annotation = GoldStandardAnnotation(
                 attribute=attribute,
+                arm_context=matched_arm,
                 raw_data=llm_annotation.output_data,
                 annotation_type=AnnotationType.LLM,
                 additional_text=additional_text,

--- a/deet/extractors/llm_data_extractor.py
+++ b/deet/extractors/llm_data_extractor.py
@@ -315,7 +315,7 @@ class LLMDataExtractor:
             logger.warning(f"LLM did not return valid {entity_name}: {e}")
             return cast(T, schema_model())
 
-    def extract_arms_from_document(self, payload: str) -> Sequence[StudyArm]:
+    def extract_arms_from_document(self, payload: str) -> tuple[StudyArm, ...]:
         """Extract outcomes from a document."""
         system_prompt = (
             "You are an expert systematic review data extraction assistant."
@@ -338,7 +338,7 @@ class LLMDataExtractor:
         logger.info("Arm extraction successful." f" Found {len(result.arms)} arms")
         return result.arms
 
-    def extract_outcomes_from_document(self, payload: str) -> Sequence[StudyOutcome]:
+    def extract_outcomes_from_document(self, payload: str) -> tuple[StudyOutcome, ...]:
         """Extract outcomes from a document."""
         system_prompt = (
             "You are an expert systematic review data extraction assistant."
@@ -368,8 +368,8 @@ class LLMDataExtractor:
         self,
         attributes: list[Attribute],
         filter_attribute_ids: list[int] | None = None,
-        study_arms: Sequence[StudyArm] = [],
-        study_outcomes: Sequence[StudyOutcome] = [],
+        study_arms: tuple[StudyArm, ...] = (),
+        study_outcomes: tuple[StudyOutcome, ...] = (),
         *,
         payload: str | None = None,
         md_path: Path | None = None,
@@ -525,7 +525,10 @@ class LLMDataExtractor:
 
                     llm_annotated_docs.append(
                         GoldStandardAnnotatedDocument(
-                            document=document, annotations=result.annotations
+                            document=document,
+                            annotations=result.annotations,
+                            study_arms=tuple(study_arms),
+                            study_outcomes=tuple(study_outcomes),
                         )
                     )
                     doc_id_str = str(document.safe_identity.document_id)
@@ -650,8 +653,8 @@ class LLMDataExtractor:
         self,
         payload: str,
         attributes: list[Attribute],
-        study_arms: Sequence[StudyArm],
-        study_outcomes: Sequence[StudyOutcome],
+        study_arms: tuple[StudyArm, ...],
+        study_outcomes: tuple[StudyOutcome, ...],
     ) -> str:
         """
         Generate structured JSON input for the LLM user message.
@@ -863,8 +866,8 @@ class LLMDataExtractor:
         self,
         response_content: str,
         attributes: list[Attribute],
-        study_arms: Sequence[StudyArm],
-        study_outcomes: Sequence[StudyOutcome],
+        study_arms: tuple[StudyArm, ...],
+        study_outcomes: tuple[StudyOutcome, ...],
     ) -> list[GoldStandardAnnotation]:
         """
         Parse and validate LLM response against GoldStandardAnnotation structure.

--- a/deet/extractors/llm_data_extractor.py
+++ b/deet/extractors/llm_data_extractor.py
@@ -25,6 +25,8 @@ from deet.data_models.base import (
     LLMResponseSchema,
     StudyArm,
     StudyArmsDefinitionSchema,
+    StudyOutcome,
+    StudyOutcomesDefinitionSchema,
 )
 from deet.data_models.documents import (
     ContextType,
@@ -270,29 +272,25 @@ class LLMDataExtractor:
                 self.custom_system_prompt_file.read_text()
             )
 
-    def extract_arms_from_document(self, payload: str) -> Sequence[StudyArm]:
-        """Extract arms from a document."""
-        logger.info("Extracting study arms")
-
-        arm_prompt = (
-            f"Analyse the following document and identify all distinct study arms.\n"
-            f"Context:\n{payload}"
-        )
-
-        arm_system_prompt = (
-            "You are an expert systematic review data extraction assistant."
-            "Your task is to identify and catalogue the distinct study "
-            "arms in the text."
-            "Provide a short snake_case 'arm_id' for each, a clear title, "
-            "and a brief description."
-        )
+    def _extract_entities_from_document[
+        T: StudyArmsDefinitionSchema | StudyOutcomesDefinitionSchema
+    ](
+        self,
+        payload: str,
+        entity_name: str,
+        system_prompt: str,
+        user_instruction: str,
+        schema_model: type[T],
+    ) -> T:
+        """Extract arms or outcomes from a document."""
+        user_prompt = f"{user_instruction}\nContext:\n{payload}"
 
         messages = [
-            {"role": "system", "content": arm_system_prompt},
-            {"role": "user", "content": arm_prompt},
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
         ]
 
-        self._enforce_context_limit(messages, arm_prompt, arm_system_prompt)
+        self._enforce_context_limit(messages, user_prompt, system_prompt)
 
         response = litellm.completion(
             model=self.model,
@@ -304,7 +302,7 @@ class LLMDataExtractor:
                 "type": "json_schema",
                 "json_schema": {
                     "name": "study_arms_definition_response",
-                    "schema": StudyArmsDefinitionSchema.model_json_schema(),
+                    "schema": schema_model.model_json_schema(),
                 },
             },
         )
@@ -312,20 +310,66 @@ class LLMDataExtractor:
         response_content = response.choices[0].message.content
 
         try:
-            validated_arms = StudyArmsDefinitionSchema.model_validate_json(
-                response_content
-            )
+            return cast(T, schema_model.model_validate_json(response_content))
         except ValidationError as e:
-            logger.warning(f"LLM did not return valid arms: {e}")
-            return []
-        logger.info(f"Arm extraction successful. Found {len(validated_arms.arms)} arms")
-        return validated_arms.arms
+            logger.warning(f"LLM did not return valid {entity_name}: {e}")
+            return cast(T, schema_model())
+
+    def extract_arms_from_document(self, payload: str) -> Sequence[StudyArm]:
+        """Extract outcomes from a document."""
+        system_prompt = (
+            "You are an expert systematic review data extraction assistant."
+            " Your task is to identify and catalogue the distinct"
+            " study arms in the text."
+            " Provide a short snake_case 'arm_id' for each,"
+            " a clear title, and a brief description"
+        )
+        user_instruction = (
+            "Analyse the following document and" " identify all distinct study arms."
+        )
+
+        result = self._extract_entities_from_document(
+            payload=payload,
+            entity_name="outcomes",
+            system_prompt=system_prompt,
+            user_instruction=user_instruction,
+            schema_model=StudyArmsDefinitionSchema,
+        )
+        logger.info("Arm extraction successful." f" Found {len(result.arms)} arms")
+        return result.arms
+
+    def extract_outcomes_from_document(self, payload: str) -> Sequence[StudyOutcome]:
+        """Extract outcomes from a document."""
+        system_prompt = (
+            "You are an expert systematic review data extraction assistant."
+            " Your task is to identify and catalogue the distinct"
+            " study outcomes in the text."
+            " Provide a short snake_case 'outcome_id' for each,"
+            " a clear title, and a brief description"
+        )
+        user_instruction = (
+            "Analyse the following document and"
+            " identify all distinct study outcomes."
+        )
+
+        result = self._extract_entities_from_document(
+            payload=payload,
+            entity_name="outcomes",
+            system_prompt=system_prompt,
+            user_instruction=user_instruction,
+            schema_model=StudyOutcomesDefinitionSchema,
+        )
+        logger.info(
+            "Outcome extraction successful." f" Found {len(result.outcomes)} outcomes"
+        )
+        return result.outcomes
 
     def extract_from_document(  # noqa: PLR0913
         self,
         attributes: list[Attribute],
         filter_attribute_ids: list[int] | None = None,
         study_arms: Sequence[StudyArm] = [],
+        study_outcomes: Sequence[StudyOutcome] = [],
         *,
         payload: str | None = None,
         md_path: Path | None = None,
@@ -387,7 +431,10 @@ class LLMDataExtractor:
 
         context = self._prepare_context(payload=payload, context_type=context_type)
         prompt = self._generate_user_message_json(
-            payload=context, attributes=selected_attributes, study_arms=study_arms
+            payload=context,
+            attributes=selected_attributes,
+            study_arms=study_arms,
+            study_outcomes=study_outcomes,
         )
         llm_response, messages, output_tokens, input_tokens = self._call_llm(
             prompt=prompt
@@ -396,6 +443,7 @@ class LLMDataExtractor:
             response_content=llm_response,
             attributes=selected_attributes,
             study_arms=study_arms,
+            study_outcomes=study_outcomes,
         )
 
         return DocumentExtractionResult(
@@ -462,6 +510,9 @@ class LLMDataExtractor:
                     study_arms = self.extract_arms_from_document(
                         payload=document.context
                     )
+                    study_outcomes = self.extract_outcomes_from_document(
+                        payload=document.context
+                    )
 
                     result = self.extract_from_document(
                         attributes=attributes,
@@ -469,6 +520,7 @@ class LLMDataExtractor:
                         payload=document.context,
                         context_type=context_type,
                         study_arms=study_arms,
+                        study_outcomes=study_outcomes,
                     )
 
                     llm_annotated_docs.append(
@@ -595,7 +647,11 @@ class LLMDataExtractor:
         return context
 
     def _generate_user_message_json(
-        self, payload: str, attributes: list[Attribute], study_arms: Sequence[StudyArm]
+        self,
+        payload: str,
+        attributes: list[Attribute],
+        study_arms: Sequence[StudyArm],
+        study_outcomes: Sequence[StudyOutcome],
     ) -> str:
         """
         Generate structured JSON input for the LLM user message.
@@ -626,10 +682,12 @@ class LLMDataExtractor:
             attributes_payload.append(llm_input_attr.model_dump())
 
         arms_payload = [arm.model_dump() for arm in study_arms]
+        outcomes_payload = [outcome.model_dump() for outcome in study_outcomes]
 
         unserialised_prompt = {
             "context": payload,
             "study_arms": arms_payload,
+            "study_outcomes": outcomes_payload,
             "attributes": attributes_payload,
         }
 
@@ -688,12 +746,14 @@ class LLMDataExtractor:
             context = prompt_data.get("context", "")
             attributes_payload = prompt_data.get("attributes", [])
             arms_payload = prompt_data.get("study_arms", [])
+            outcomes_payload = prompt_data.get("study_arms", [])
 
             overhead_part = json.dumps(
                 {
                     "context": "",
                     "attributes": attributes_payload,
                     "study_arms": arms_payload,
+                    "study_outcomes": outcomes_payload,
                 },
                 ensure_ascii=False,
             )
@@ -804,6 +864,7 @@ class LLMDataExtractor:
         response_content: str,
         attributes: list[Attribute],
         study_arms: Sequence[StudyArm],
+        study_outcomes: Sequence[StudyOutcome],
     ) -> list[GoldStandardAnnotation]:
         """
         Parse and validate LLM response against GoldStandardAnnotation structure.
@@ -871,6 +932,25 @@ class LLMDataExtractor:
                         f"of the extracted arms. Defaulting arm_context to None."
                     )
 
+            matched_outcome = None
+            if llm_annotation.outcome_id is not None:
+                matched_outcome = next(
+                    (
+                        study_outcome
+                        for study_outcome in study_outcomes
+                        if study_outcome.outcome_id == llm_annotation.outcome_id
+                    ),
+                    None,
+                )
+                if not matched_arm:
+                    logger.warning(
+                        f"LLM returned outcome_id '{llm_annotation.arm_id}'"
+                        " for attribute"
+                        f"{attribute.attribute_id}, but it doesn't match any"
+                        f"of the extracted outcomes."
+                        " Defaulting outcome_context to None."
+                    )
+
             additional_text = (
                 llm_annotation.additional_text
                 if self.config.include_additional_text
@@ -883,6 +963,7 @@ class LLMDataExtractor:
             annotation = GoldStandardAnnotation(
                 attribute=attribute,
                 arm_context=matched_arm,
+                outcome_context=matched_outcome,
                 raw_data=llm_annotation.output_data,
                 annotation_type=AnnotationType.LLM,
                 additional_text=additional_text,


### PR DESCRIPTION
# Support arm-level annotations

## Description

Current state: draft with MWE!

### Introduce study arms and study outcomes to base data models

`deet` uses `GoldStandardAnnotation` objects to record the value of an extracted attribute. Previously, each `GoldStandardAnnotation` was attached to an attribute (and a GoldStandardAnnotatedDocument attached a list of annotations to a document).

In this PR an annotation *can* also be attached to an arm and an outcome:

https://github.com/destiny-evidence/data-extraction-evaluation-toolkit/blob/24716d478755c0a7a3654c234f483e483063abcf/deet/data_models/base.py#L388-L427

Attributes themselves can be defined as outcome- or arm-specific.

https://github.com/destiny-evidence/data-extraction-evaluation-toolkit/blob/24716d478755c0a7a3654c234f483e483063abcf/deet/data_models/base.py#L110-L129

For example, an attribute that gives further information on an arm, (e.g. the number, or average age of patients treated with a drug, or the number of counties in which a policy was implemented) could be captured with an arm-specific, but not outcome-specific attribute, since these attributes do not relate to a specific outcome.

Conversely, some information about the outcome, (e.g. the number of years after treatment in which this was measured) could be captured with an outcome-specific but not arm specific attribute.

Finally, an effect of an intervention on a study group (e.g. **effect size** (attribute) of the **change survival rates** after 1 year (outcome) in the **group treated with treatment X** (arm) could be captured with an outcome-specific and arm-specific attribute.

### Adjust llm data extractor to first extract arms and outcomes from a study, then attach these arms and outcomes to annotations where appropriate.

In this PR, arms and outcomes are extracted in a first pass of documents. These arms and outcomes are then included in the prompt sent as part of the main extraction task, and arm- or outcome- specific annotations are then attached to the arm and outcome objects created in the first pass 

https://github.com/destiny-evidence/data-extraction-evaluation-toolkit/blob/24716d478755c0a7a3654c234f483e483063abcf/deet/extractors/llm_data_extractor.py#L510-L524 

### edit evaluator to iterate through attributes and arms and outcomes

Since annotations no longer apply uniquely to document-attribute combinations, the evaluator now loops through all combinations of documents, attributes, arms, and outcomes.

We will need to implement some sort of fuzzy-matching on arms between gold standard and llm extractions. This may be made easier by defining intervention and outcome types at a review level, and then asking the llm to match to these on extraction from individual studies, as is done in RevMan.

## Related Issue(s)

#285 
#283 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [ ] All existing and new tests pass locally and in CI
- [ ] Core functionality still works locally (e.g. all pipeline scripts)
- [ ] Code passes `ruff` linting
- [ ] Code passes `mypy` type checking
- [ ] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [ ] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [ ] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
<!-- Describe how you tested your changes, interactively and formally. -->

## Additional Notes

## Todos
- [ ] Adjust eppijson parser to parse arms in standardised format
- [ ] Adjust csv parser to parse arms in standardised format
- [ ] Tests
- [ ] ...

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
