### PR TITLE
Use mike to publish multi-version documentation, including development

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -64,6 +64,4 @@ jobs:
             uv run mike set-default --push latest
           elif [ "${{ github.ref_name }}" = "development" ]; then
             uv run mike deploy --push --update-aliases development
-          elif [ "${{ github.ref_name }}" = "main" ]; then
-            uv run mike deploy --push --update-aliases stable
           fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+      - development
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
+      - development
 
 permissions:
   contents: write
@@ -51,10 +55,15 @@ jobs:
       # first time this workflow step is run.
       - name: Publish documentation on GitHub pages
         if: success() && github.event_name != 'pull_request'
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
-        with:
-          github_token: ${{  secrets.GITHUB_TOKEN }}
-          publish_dir: site
-          publish_branch: gh-pages
-          user_name: "github-actions[bot]"
-          user_email: "github-actions[bot]@users.noreply.github.com"
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            uv run mike deploy --push --update-aliases ${{ github.ref_name }} latest
+            uv run mike set-default --push latest
+          elif [ "${{ github.ref_name }}" = "development" ]; then
+            uv run mike deploy --push --update-aliases development
+          elif [ "${{ github.ref_name }}" = "main" ]; then
+            uv run mike deploy --push --update-aliases stable
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,22 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
-
-      - name: Set up Python
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          python-version: "3.x"
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
+          fetch-depth: 0 # required for mike to access tags and commit history
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.1.0
         with:
-          version: "0.8.11"
+          version: "0.11.11"
 
       - name: Restore uv cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/.uv-cache
           key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
@@ -47,21 +42,48 @@ jobs:
         run: uv sync --locked --group docs
 
       - name: Build documentation
+        if: github.event_name == 'pull_request' || github.ref_name == 'main'
         run: uv run mkdocs build
 
-      # Automatically deploy documentation to a GitHub Pages website on pushing to main.
-      # Requires configuring the repository to deploy GitHub pages from a branch
-      # gh-pages (https://tinyurl.com/gh-pages-from-branch), which will be created the
-      # first time this workflow step is run.
-      - name: Publish documentation on GitHub pages
-        if: success() && github.event_name != 'pull_request'
+      - name: Deploy versioned docs with mike
+        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'development')
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages:gh-pages || true
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if [ "${{ github.ref_type }}" = "tag" ]; then
-            uv run mike deploy --push --update-aliases ${{ github.ref_name }} latest
-            uv run mike set-default --push latest
+            uv run mike deploy --update-aliases ${{ github.ref_name }} stable
+            uv run mike set-default --push stable
           elif [ "${{ github.ref_name }}" = "development" ]; then
-            uv run mike deploy --push --update-aliases development
+            uv run mike deploy --update-aliases development
           fi
+
+      - name: Push gh-pages branch
+        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'development')
+        run: git push origin gh-pages
+
+      - name: Switch to gh-pages for artifact upload
+        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'development')
+        run: git checkout gh-pages
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'development')
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: .
+
+  deploy:
+    needs: docs
+    if: github.event_name != 'pull_request' && (github.ref_type == 'tag' || github.ref_name == 'development')
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,8 @@ plugins:
       closing_tag: "!}"
 
 extra:
+  version:
+    provider: mike
   social:
     - icon: fontawesome/brands/github
       link: "https://github.com/destiny-evidence"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dev = [
 ]
 docs = [
     "griffe-pydantic>=1.3.1",
+    "mike>=2.2.0",
     "mkdocs-include-markdown-plugin>=7.2.0",
     "mkdocs-material>=9.7.0",
     "mkdocs-mermaid2-plugin>=1.2.3",

--- a/uv.lock
+++ b/uv.lock
@@ -654,6 +654,7 @@ dev = [
 ]
 docs = [
     { name = "griffe-pydantic" },
+    { name = "mike" },
     { name = "mkdocs" },
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
@@ -697,6 +698,7 @@ dev = [
 ]
 docs = [
     { name = "griffe-pydantic", specifier = ">=1.3.1" },
+    { name = "mike", specifier = ">=2.2.0" },
     { name = "mkdocs", specifier = ">=1.6.1,<2.0" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.2.0" },
     { name = "mkdocs-material", specifier = ">=9.7.0" },
@@ -1543,6 +1545,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
 ]
 
 [[package]]
@@ -2534,6 +2553,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pypdfium2"
 version = "4.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3437,6 +3465,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Description

- Configure mkdocs.yml to use mike as version provider
- Adjust docs workflow to create a new version of the docs whenever 
  - A version is tagged (update latest)
  - Development is updated (update development)
  
After this, 

- https://destiny-evidence.github.io/data-extraction-evaluation-toolkit/latest will always point to documentation for the latest tagged version
- https://destiny-evidence.github.io/data-extraction-evaluation-toolkit/ will also default to latest
- https://destiny-evidence.github.io/data-extraction-evaluation-toolkit/development will always point to documentation in line with the development branch
- https://destiny-evidence.github.io/data-extraction-evaluation-toolkit/v0.2.0 will always point to documentation for v0.2.0

## Related Issue(s)
Closes #242 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement/modification to existing feature
- [x] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [x] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing

Hard to test the workflow, I think we should see what happens when we merge to dev, but have confirmed that

```sh
uv run mike deploy development "Development"
uv run mike serve
```

works as expected.

## Additional Notes
<!-- Other context, screenshots, or information reviewers should know. Keep in mind text is better than a screenshot of text. -->

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
