### PR TITLE
fix: update generic types to follow PEP 695

### DIFF
--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from io import BytesIO
 from pathlib import Path
 from random import randint
-from typing import Any, Generic, Literal, Self, TypeVar
+from typing import Any, Literal, Self
 
 from destiny_sdk.labs.references import LabsReference
 from destiny_sdk.references import ReferenceFileInput
@@ -20,7 +20,6 @@ from deet.data_models.base import (
     AnnotationType,
     Attribute,
     GoldStandardAnnotation,
-    GoldStandardAnnotationTypeVar,
 )
 from deet.exceptions import (
     BadDocumentIdError,
@@ -552,16 +551,14 @@ class Document(BaseModel):
         return cls(**data)
 
 
-DocumentTypeVar = TypeVar("DocumentTypeVar", bound=Document)
-
-
-class GoldStandardAnnotatedDocument(
-    BaseModel, Generic[DocumentTypeVar, GoldStandardAnnotationTypeVar]
-):
+class GoldStandardAnnotatedDocument[
+    DocumentType: Document,
+    GoldStandardAnnotationType: GoldStandardAnnotation,
+](BaseModel):
     """A document with its gold standard annotations."""
 
-    document: DocumentTypeVar
-    annotations: list[GoldStandardAnnotationTypeVar]
+    document: DocumentType
+    annotations: list[GoldStandardAnnotationType]
 
     def get_attribute_annotation(self, attribute: Attribute) -> GoldStandardAnnotation:
         """Get the value of the annotation of the corresponding attribute."""
@@ -600,32 +597,27 @@ class GoldStandardAnnotatedDocument(
         return result
 
 
-GoldStandardAnnotatedDocumentTypeVar = TypeVar(
-    "GoldStandardAnnotatedDocumentTypeVar", bound=GoldStandardAnnotatedDocument
-)
-
-
-class GoldStandardAnnotatedDocumentList(
-    BaseModel, Generic[GoldStandardAnnotatedDocumentTypeVar]
-):
+class GoldStandardAnnotatedDocumentList[
+    GoldStandardAnnotatedDocumentType: GoldStandardAnnotatedDocument[Any, Any]
+](BaseModel):
     """
-    A list of GoldStandardAnnotatedDocuments (or subclasses thereof).
+    A list of GoldStandardAnnotatedDocuments (or any subclasses thereof).
     This list is indexed to enable easy retrieval by document_id.
     """
 
-    gold_standard_annotations: Sequence[GoldStandardAnnotatedDocumentTypeVar]
+    gold_standard_annotations: Sequence[GoldStandardAnnotatedDocumentType]
 
     @cached_property
-    def annotation_index(self) -> dict[int, GoldStandardAnnotatedDocumentTypeVar]:
+    def annotation_index(self) -> dict[int, GoldStandardAnnotatedDocumentType]:
         """Cached index to enable retrieving annotated documents by id."""
         return {
             doc.document.safe_identity.document_id: doc
             for doc in self.gold_standard_annotations
         }
 
-    def get_by_id(self, document_id: int) -> GoldStandardAnnotatedDocumentTypeVar:
+    def get_by_id(self, document_id: int) -> GoldStandardAnnotatedDocumentType:
         """
-        Get GoldStandardAnnotatedDocument where document.document_identity
+        Get GoldStandardAnnotatedDocuments where document.document_identity
         matches document_identity.
         """
         try:

--- a/deet/data_models/processed_gold_standard_annotations.py
+++ b/deet/data_models/processed_gold_standard_annotations.py
@@ -3,7 +3,7 @@
 import csv
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Generic, Literal
+from typing import Any, Literal
 
 from loguru import logger
 from pydantic import BaseModel
@@ -13,12 +13,11 @@ from deet.data_models.base import (
     AnnotationType,
     Attribute,
     AttributeType,
-    AttributeTypeVar,
-    GoldStandardAnnotationTypeVar,
+    GoldStandardAnnotation,
 )
 from deet.data_models.documents import (
-    DocumentTypeVar,
-    GoldStandardAnnotatedDocumentTypeVar,
+    Document,
+    GoldStandardAnnotatedDocument,
 )
 from deet.data_models.enums import CustomPromptPopulationMethod
 from deet.data_models.eppi import (
@@ -31,7 +30,7 @@ from deet.data_models.eppi import (
 from deet.processors.linker import DocumentReferenceLinker
 
 
-class ProcessedAttributeData(BaseModel, Generic[AttributeTypeVar]):
+class ProcessedAttributeData[AttributeT: Attribute](BaseModel):
     """
     Structured result from annotation processing.
 
@@ -39,7 +38,7 @@ class ProcessedAttributeData(BaseModel, Generic[AttributeTypeVar]):
     subclass this
     """
 
-    attributes: list[AttributeTypeVar]
+    attributes: list[AttributeT]
 
     def _custom_prompts_cli(self) -> None:
         """
@@ -255,15 +254,12 @@ class ProcessedAttributeData(BaseModel, Generic[AttributeTypeVar]):
         return len(self.attributes)
 
 
-class ProcessedAnnotationData(
-    ProcessedAttributeData,
-    Generic[
-        AttributeTypeVar,
-        DocumentTypeVar,
-        GoldStandardAnnotationTypeVar,
-        GoldStandardAnnotatedDocumentTypeVar,
-    ],
-):
+class ProcessedAnnotationData[
+    AttributeT: Attribute,
+    DocumentType: Document,
+    GoldStandardAnnotationType: GoldStandardAnnotation,
+    GoldStandardAnnotatedDocumentType: GoldStandardAnnotatedDocument,
+](ProcessedAttributeData[AttributeT]):
     """
     Structured result from annotation processing.
 
@@ -271,9 +267,9 @@ class ProcessedAnnotationData(
     annotation data with useful properties and methods.
     """
 
-    documents: list[DocumentTypeVar]
-    annotations: list[GoldStandardAnnotationTypeVar]
-    annotated_documents: list[GoldStandardAnnotatedDocumentTypeVar]
+    documents: list[DocumentType]
+    annotations: list[GoldStandardAnnotationType]
+    annotated_documents: list[GoldStandardAnnotatedDocumentType]
     attribute_id_to_label: dict[int, str]
 
     @property
@@ -293,13 +289,13 @@ class ProcessedAnnotationData(
 
     def get_attributes_by_attribute_type(
         self, attribute_type: AttributeType
-    ) -> list[AttributeTypeVar]:
+    ) -> list[AttributeT]:
         """Get all attributes of a specific type."""
         return [
             attr for attr in self.attributes if attr.output_data_type == attribute_type
         ]
 
-    def get_documents_with_annotations(self) -> list[DocumentTypeVar]:
+    def get_documents_with_annotations(self) -> list[DocumentType]:
         """Get only documents that have annotations."""
         annotated_doc_ids = {
             doc.document.document_id for doc in self.annotated_documents
@@ -308,7 +304,7 @@ class ProcessedAnnotationData(
 
     def get_annotations_by_annotation_type(
         self, annotation_type: AnnotationType
-    ) -> list[GoldStandardAnnotationTypeVar]:
+    ) -> list[GoldStandardAnnotationType]:
         """Get all annotations of a specific type (human/llm)."""
         return [
             ann for ann in self.annotations if ann.annotation_type == annotation_type

--- a/deet/evaluators/gold_standard_llm_evaluator.py
+++ b/deet/evaluators/gold_standard_llm_evaluator.py
@@ -16,10 +16,10 @@ from rapidfuzz import fuzz
 from rich.console import Console
 from rich.table import Table
 
-from deet.data_models.base import AttributeTypeVar
+from deet.data_models.base import Attribute
 from deet.data_models.documents import (
+    GoldStandardAnnotatedDocument,
     GoldStandardAnnotatedDocumentList,
-    GoldStandardAnnotatedDocumentTypeVar,
 )
 from deet.data_models.evaluation import (
     METRICS,
@@ -121,11 +121,9 @@ class GoldStandardLLMEvaluator:
 
     def __init__(
         self,
-        gold_standard_annotated_documents: Sequence[
-            GoldStandardAnnotatedDocumentTypeVar
-        ],
-        llm_annotated_documents: Sequence[GoldStandardAnnotatedDocumentTypeVar],
-        attributes: Sequence[AttributeTypeVar],
+        gold_standard_annotated_documents: Sequence[GoldStandardAnnotatedDocument],
+        llm_annotated_documents: Sequence[GoldStandardAnnotatedDocument],
+        attributes: Sequence[Attribute],
         extraction_run_id: str,
         custom_metrics: list[str] | None = None,
     ) -> None:

--- a/deet/processors/base_converter.py
+++ b/deet/processors/base_converter.py
@@ -4,16 +4,15 @@ import json
 from abc import ABC, abstractmethod
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import Generic
 
 from loguru import logger
 from pydantic import TypeAdapter
 
-from deet.data_models.base import AttributeType, AttributeTypeVar
+from deet.data_models.base import Attribute, AttributeType
 from deet.data_models.documents import (
-    DocumentTypeVar,
-    GoldStandardAnnotatedDocumentTypeVar,
-    GoldStandardAnnotationTypeVar,
+    Document,
+    GoldStandardAnnotatedDocument,
+    GoldStandardAnnotation,
 )
 from deet.data_models.processed_gold_standard_annotations import ProcessedAnnotationData
 
@@ -33,15 +32,12 @@ class Outfiles(StrEnum):
     ATTRIBUTE_LABEL_MAPPING = auto()
 
 
-class AnnotationConverter(
-    Generic[
-        DocumentTypeVar,
-        AttributeTypeVar,
-        GoldStandardAnnotationTypeVar,
-        GoldStandardAnnotatedDocumentTypeVar,
-    ],
-    ABC,
-):
+class AnnotationConverter[
+    DocumentType: Document,
+    AttributeT: Attribute,
+    GoldStandardAnnotationType: GoldStandardAnnotation,
+    GoldStandardAnnotatedDocumentType: GoldStandardAnnotatedDocument,
+](ABC):
     """
     Abstract base class to define expected behaviour of an annotationconverter.
 
@@ -85,10 +81,10 @@ class AnnotationConverter(
         self,
     ) -> type[
         ProcessedAnnotationData[
-            AttributeTypeVar,
-            DocumentTypeVar,
-            GoldStandardAnnotationTypeVar,
-            GoldStandardAnnotatedDocumentTypeVar,
+            AttributeT,
+            DocumentType,
+            GoldStandardAnnotationType,
+            GoldStandardAnnotatedDocumentType,
         ]
     ]:
         """Return the class to use when instantiating processed data."""


### PR DESCRIPTION
# Pull Request

## Description
This PR doesn't change how deet works, but updates the way generic types are defined in those classes that use generic types in order to accomodate base / EPPI documents and attributes.

These are now defined in a way that is compliant with [PEP 695](https://peps.python.org/pep-0695/), making the code easier to read and maintain.

## Related Issue(s)
Closes #250 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [x] Other (please describe): Code maintainability improvement

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [x] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
Automated tests still pass. CLI works as usual. Changes have no effect at runtime.

## Additional Notes

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
