### PR TITLE
feat: add keyword and semantic extractors, and introduce a shared ABC…

### DIFF
--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -20,6 +20,7 @@ class AnnotationType(StrEnum):
 
     HUMAN = auto()
     LLM = auto()
+    KEYWORD = auto()
 
 
 class AttributeType(StrEnum):

--- a/deet/extractors/base_extractor.py
+++ b/deet/extractors/base_extractor.py
@@ -1,0 +1,410 @@
+"""Base data extraction module to be extended with different extraction methods."""
+
+import json
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from enum import StrEnum, auto
+from importlib.resources import files
+from pathlib import Path
+from typing import Annotated, Any
+
+import yaml
+from loguru import logger
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    model_validator,
+)
+
+from deet.data_models.base import Attribute
+from deet.data_models.documents import (
+    ContextType,
+    Document,
+    GoldStandardAnnotatedDocument,
+)
+from deet.data_models.extraction import (
+    DocumentExtractionResult,
+    ExtractionRunMetadata,
+    ExtractionRunOutput,
+)
+from deet.data_models.ui_schema import UI
+from deet.exceptions import LitellmModelNotMappedError
+from deet.settings import (
+    DEFAULT_LLM_MAX_CONTEXT_TOKENS_FALLBACK,
+    LLMProvider,
+)
+from deet.ui.terminal.render import optional_progress
+from deet.utils.tokenisation import (
+    get_model_max_tokens,
+)
+
+
+def default_system_prompt() -> str:
+    """Get default system prompt included in the package."""
+    return (files("deet.prompts") / "system_prompt.txt").read_text()
+
+
+def _model_string_for_tokenisation(provider: LLMProvider, model: str) -> str:
+    """
+    Build the model string used for tokenisation.
+
+    Must match how ``LLMDataExtractor`` sets ``self.model`` from config.
+    """
+    match provider:
+        case LLMProvider.AZURE:
+            return f"azure/{model}"
+        case LLMProvider.OLLAMA:
+            return f"ollama/{model}"
+        case _:
+            msg = f"Unsupported LLM provider: {provider}"
+            raise ValueError(msg)
+
+
+class PromptConfig(BaseModel):
+    """Configuration for prompts used in data extraction."""
+
+    model_config = ConfigDict()
+
+    system_prompt: str | Path = Field(
+        description="System prompt that defines the task and role",
+        default_factory=default_system_prompt,
+    )
+
+    @model_validator(mode="after")
+    def load_system_prompt_file(self) -> "PromptConfig":
+        """Load system prompt from file if Path provided."""
+        if isinstance(self.system_prompt, Path):
+            if not self.system_prompt.exists():
+                sys_prompt_missing = f"sys prompt {self.system_prompt} not found."
+                raise ValueError(sys_prompt_missing)
+            logger.debug(f"Reading system prompt from {self.system_prompt}")
+            self.system_prompt = self.system_prompt.read_text()
+
+        return self
+
+
+class ExtractionMethod(StrEnum):
+    """Enum of extraction methods."""
+
+    LLM = auto()
+    KEYWORD = auto()
+    SEMANTIC = auto()
+
+
+class DataExtractionConfig(BaseModel):
+    """Configuration for data extraction tasks."""
+
+    model_config = ConfigDict()
+
+    method: ExtractionMethod = Field(
+        default=ExtractionMethod.LLM, description="Extraction Method"
+    )
+
+    # LLM
+    provider: Annotated[
+        LLMProvider, UI(help="Choose from a list of supported LLM providers.")
+    ] = Field(default=LLMProvider.AZURE, description="LLM Provider")
+    model: Annotated[str, UI(help="The name of the LLM model you want to use.")] = (
+        Field(
+            default="gpt-4o-mini",
+            description="LLM model identifier used for completions.",
+        )
+    )
+    temperature: float = Field(
+        default=0.1,
+        description="Sampling temperature for the LLM.",
+        ge=0.0,
+    )
+    max_tokens: Annotated[
+        int | None,
+        UI(
+            help=(
+                "The maximum number of tokens in the LLM response. "
+                "Leave blank for the provider default."
+            )
+        ),
+    ] = Field(
+        default=None,
+        description=(
+            "Maximum number of tokens to generate (Leave blank for provider default)."
+        ),
+    )
+
+    max_context_tokens: Annotated[
+        int | None,
+        UI(
+            help=("Maximum input context length " "(Leave blank for provider default).")
+        ),
+    ] = Field(
+        default=None,
+        description=(
+            "Maximum input context length in tokens (system + attributes + "
+            "document). None = infer from model (litellm registry), else "
+            f"{DEFAULT_LLM_MAX_CONTEXT_TOKENS_FALLBACK} via "
+            "DEFAULT_LLM_MAX_CONTEXT_TOKENS_FALLBACK. Override to manage costs."
+        ),
+    )
+
+    # Context
+    default_context_type: Annotated[
+        ContextType, UI(help="Where to extract data from.")
+    ] = Field(
+        default=ContextType.FULL_DOCUMENT, description="Type of context to provide"
+    )
+
+    truncate_on_overflow: Annotated[
+        bool,
+        UI(
+            help=(
+                "Select true to truncate documents longer than max_context_tokens. "
+                "This will ensure extraction runs without crashing, but may mean"
+                " some parts of the document are not seen by the LLM."
+            )
+        ),
+    ] = Field(
+        default=False,
+        description=(
+            "When True, automatically truncate context that exceeds "
+            "max_context_tokens. When False (default), raise ValueError."
+        ),
+    )
+
+    # Prompt
+    prompt_config: PromptConfig = Field(
+        default_factory=PromptConfig, description="Prompt configuration"
+    )
+
+    # Output
+    include_reasoning: bool = Field(
+        default=True, description="Include reasoning in output"
+    )
+    include_additional_text: bool = Field(
+        default=True, description="Include additional text/citations in output"
+    )
+
+    @model_validator(mode="after")
+    def populate_max_context_tokens_from_model(self) -> "DataExtractionConfig":
+        """Populate max_context_tokens from model when not set."""
+        if self.max_context_tokens is not None:
+            return self
+        model_str = _model_string_for_tokenisation(self.provider, self.model)
+        try:
+            inferred = get_model_max_tokens(model_str)
+        except LitellmModelNotMappedError:
+            inferred = None
+        if inferred is not None:
+            self.max_context_tokens = inferred
+        else:
+            # Use shared fallback when model max tokens cannot be inferred.
+            self.max_context_tokens = DEFAULT_LLM_MAX_CONTEXT_TOKENS_FALLBACK
+        return self
+
+    @classmethod
+    def from_yaml(cls, path: Path) -> "DataExtractionConfig":
+        """Load config object from a yaml file."""
+        if not path.exists():
+            not_found = f"Config file not found at: {path}"
+            raise FileNotFoundError(not_found)
+
+        return cls.model_validate(yaml.safe_load(path.read_text()))
+
+
+class BaseDataExtractor(ABC):
+    """Abstract Base Class defining common methods for data extractors."""
+
+    def __init__(self, config: DataExtractionConfig) -> None:
+        """Initialise with data extraction config."""
+        self.config = config
+
+    def _prepare_context(
+        self,
+        payload: str,
+        context_type: ContextType | None = None,
+    ) -> str:
+        """Prepare context based on context type."""
+        ctx = (
+            context_type
+            if context_type is not None
+            else self.config.default_context_type
+        )
+        logger.debug(f"Using context type: {ctx}")
+        if ctx == ContextType.FULL_DOCUMENT:
+            context = payload
+            logger.debug(f"Using full document context (length: {len(str(context))})")
+        elif ctx == ContextType.ABSTRACT_ONLY:
+            context = payload
+            logger.debug(f"Using abstract context (length: {len(str(context))})")
+        elif ctx == ContextType.RAG_SNIPPETS:
+            rag_not_impl = "rag-snippets context type is not implemented."
+            raise NotImplementedError(rag_not_impl)
+        elif ctx == ContextType.CUSTOM:
+            custom_not_impl = "custom context type is not implemented."
+            raise NotImplementedError(custom_not_impl)
+        else:
+            other_not_allowed = f"{ctx} context type is not allowed."
+            raise ValueError(other_not_allowed)
+
+        if isinstance(context, list):
+            logger.debug(f"Converting list context to string (items: {len(context)})")
+            context = " ".join(context)
+
+        return context
+
+    def extract_from_documents(  # noqa: PLR0913
+        self,
+        attributes: list[Attribute],
+        documents: Sequence[Document],
+        filter_attribute_ids: list[int] | None = None,
+        output_file: Path | None = None,
+        context_type: ContextType | None = None,
+        prompt_outfile: Path | None = None,
+        *,
+        show_progress: bool = False,
+    ) -> ExtractionRunOutput:
+        """
+        Extract data from all documents.
+
+        Loops over documents and extracts data using list of attributes.
+
+        Args:
+            attributes: List of attributes to extract.
+            documents: Sequence of Document instances (required).
+            filter_attribute_ids: Optional list of attribute IDs to filter by.
+            output_file: Optional path to save combined results JSON.
+            context_type: Override config context type; if None, use config default.
+            prompt_outfile: Optional path to write a single JSON object:
+                keys are document IDs, values are prompt payload (messages).
+            show_progress: Whether to show a progress bar.
+
+        Returns:
+            ExtractionRunOutput containing annotated documents and run metadata.
+
+        """
+        if context_type is None:
+            context_type = self.config.default_context_type
+
+        prompt_payloads: dict[str, Any] = {}
+        per_doc_tokens: dict[str, dict[str, int]] = {}
+
+        annotated_docs: list[GoldStandardAnnotatedDocument] = []
+        total_input_tokens = 0
+        total_output_tokens = 0
+        total_cost: float | None = None
+
+        with optional_progress(
+            documents, show_progress=show_progress
+        ) as iterable_documents:
+            for document in iterable_documents:
+                logger.info(f"Processing document: {document.name}")
+
+                if context_type == ContextType.ABSTRACT_ONLY:
+                    document.set_abstract_context()
+                elif context_type == ContextType.FULL_DOCUMENT:
+                    document.context = document.safe_parsed_document.text
+
+                try:
+                    result = self.extract_from_document(
+                        attributes=attributes,
+                        filter_attribute_ids=filter_attribute_ids,
+                        payload=document.context,
+                        context_type=context_type,
+                    )
+
+                    annotated_docs.append(
+                        GoldStandardAnnotatedDocument(
+                            document=document, annotations=result.annotations
+                        )
+                    )
+                    doc_id_str = str(document.safe_identity.document_id)
+                    prompt_payloads[doc_id_str] = result.messages
+                    per_doc_tokens[doc_id_str] = {
+                        "input_tokens": result.input_tokens,
+                        "output_tokens": result.output_tokens,
+                    }
+                    total_input_tokens += result.input_tokens
+                    total_output_tokens += result.output_tokens
+                    if result.total_cost_usd is not None:
+                        total_cost = (total_cost or 0.0) + result.total_cost_usd
+
+                except Exception as e:  # noqa: BLE001
+                    logger.error(f"Failed to process {document.name}: {e}")
+                    logger.debug("Error details", exc_info=True)
+
+        run_metadata = ExtractionRunMetadata(
+            model=self.config.model,
+            total_input_tokens=total_input_tokens,
+            total_output_tokens=total_output_tokens,
+            total_cost_usd=round(total_cost, 6) if total_cost is not None else None,
+            per_document_tokens=per_doc_tokens,
+        )
+        run_output = ExtractionRunOutput(
+            annotated_documents=annotated_docs,
+            metadata=run_metadata,
+        )
+
+        if output_file is not None:
+            self._save_results(run_output, output_file)
+            logger.info(f"Combined LLM classifications written to: {output_file}")
+
+        if prompt_outfile is not None:
+            prompt_outfile.write_text(
+                json.dumps(prompt_payloads, indent=2), encoding="utf-8"
+            )
+            logger.info(f"Prompt payloads saved to: {prompt_outfile}")
+
+        return run_output
+
+    @abstractmethod
+    def extract_from_document(
+        self,
+        attributes: list[Attribute],
+        filter_attribute_ids: list[int] | None = None,
+        *,
+        payload: str | None = None,
+        md_path: Path | None = None,
+        context_type: ContextType | None = None,
+    ) -> DocumentExtractionResult:
+        """
+        Extract data from a single document.
+
+        Call with either payload (document text) or md_path (path to markdown file).
+        If md_path is provided, the file is read and used as the payload.
+        Prompt payloads are not written here; the batch entry point
+        extract_from_documents writes them to prompt_outfile when provided.
+
+        Args:
+            attributes: List of attributes to extract.
+            payload: Document text to extract from. Required if md_path not set.
+            md_path: Path to a markdown file to read as payload.
+                Required if payload not set.
+            context_type: Override config context type; if None, use config default.
+
+        Returns:
+            DocumentExtractionResult with annotations, messages, token counts,
+            cost, model name, and timestamp.
+
+        Raises:
+            ValueError: If no attributes are selected for extraction after filtering.
+            ValueError: If neither payload nor md_path provided, or both provided.
+
+        """
+
+    def _save_results(
+        self,
+        run_output: ExtractionRunOutput,
+        output_file: Path,
+    ) -> None:
+        """
+        Serialize an ExtractionRunOutput to JSON and write it to disk.
+
+        Args:
+            run_output: The complete extraction run output to persist.
+            output_file: Destination file path.
+
+        """
+        output_file.write_text(
+            run_output.model_dump_json(indent=2),
+            encoding="utf-8",
+        )
+        logger.info(f"Results saved to: {output_file}")

--- a/deet/extractors/cli_helpers.py
+++ b/deet/extractors/cli_helpers.py
@@ -11,13 +11,11 @@ from pydantic import ValidationError
 
 from deet.data_models.documents import ContextType, Document
 from deet.data_models.enums import CustomPromptPopulationMethod
+from deet.data_models.extraction import ExtractionRunOutput
 from deet.data_models.processed_gold_standard_annotations import ProcessedAnnotationData
 from deet.data_models.project import DeetProject, ExperimentArtefacts
-from deet.extractors.llm_data_extractor import (
-    DataExtractionConfig,
-    ExtractionRunOutput,
-    LLMDataExtractor,
-)
+from deet.extractors.base_extractor import DataExtractionConfig
+from deet.extractors.extractor_registry import get_data_extractor
 from deet.processors.directory_processor import create_documents_from_directory
 from deet.processors.linker import DocumentReferenceLinker, LinkingStrategy
 from deet.ui import fail_with_message, notify
@@ -157,8 +155,6 @@ def run_extraction_pipeline(
     ignore_references: bool = False,
 ) -> tuple[ExtractionRunOutput, ProcessedAnnotationData, ExperimentArtefacts]:
     """Run the standard data extraction pipeline from the CLI."""
-    import yaml
-
     deet_project: DeetProject = typer_context.obj.project
     processed_annotation_data = deet_project.process_data()
 
@@ -175,7 +171,7 @@ def run_extraction_pipeline(
                 "No attributes selected. Perhaps you forgot to edit your prompt file"
             )
 
-    data_extractor = LLMDataExtractor(config=config)
+    data_extractor = get_data_extractor(config=config)
 
     if ignore_references:
         if deet_project.pdf_dir is None:

--- a/deet/extractors/extractor_registry.py
+++ b/deet/extractors/extractor_registry.py
@@ -1,0 +1,21 @@
+"""Registry of extraction methods and their extractors."""
+
+from deet.extractors.base_extractor import (
+    BaseDataExtractor,
+    DataExtractionConfig,
+    ExtractionMethod,
+)
+from deet.extractors.keyword_extractor import KeywordDataExtractor
+from deet.extractors.llm_data_extractor import LLMDataExtractor
+from deet.extractors.semantic_keyword_extractor import SemanticKeywordDataExtractor
+
+extractor_mapping: dict[ExtractionMethod, type[BaseDataExtractor]] = {
+    ExtractionMethod.LLM: LLMDataExtractor,
+    ExtractionMethod.KEYWORD: KeywordDataExtractor,
+    ExtractionMethod.SEMANTIC: SemanticKeywordDataExtractor,
+}
+
+
+def get_data_extractor(config: DataExtractionConfig) -> BaseDataExtractor:
+    """Instantiate the extractor registered for the given method."""
+    return extractor_mapping[config.method](config=config)

--- a/deet/extractors/keyword_extractor.py
+++ b/deet/extractors/keyword_extractor.py
@@ -1,0 +1,76 @@
+"""Generalisable data extraction module for keyword-based extraction."""
+
+from pathlib import Path
+from typing import cast
+
+from loguru import logger
+
+from deet.data_models.base import AnnotationType, Attribute, GoldStandardAnnotation
+from deet.data_models.documents import (
+    ContextType,
+)
+from deet.data_models.extraction import (
+    DocumentExtractionResult,
+)
+from deet.extractors.base_extractor import BaseDataExtractor
+
+
+class KeywordDataExtractor(BaseDataExtractor):
+    """
+    Generalisable module for LLM-based data extraction from documents.
+
+    This module provides a flexible interface for extracting structured data
+    from documents using LLMs, with support for different context types and
+    customizable prompts.
+    """
+
+    def extract_from_document(
+        self,
+        attributes: list[Attribute],
+        filter_attribute_ids: list[int] | None = None,
+        *,
+        payload: str | None = None,
+        md_path: Path | None = None,
+        context_type: ContextType | None = None,
+    ) -> DocumentExtractionResult:
+        """Extract data from a single document."""
+        if (payload is None and md_path is None) or (
+            payload is not None and md_path is not None
+        ):
+            msg = "Exactly one of payload or md_path must be provided"
+            raise ValueError(msg)
+        if md_path is not None:
+            if not md_path.exists():
+                msg = f"Markdown file not found: {md_path}"
+                raise FileNotFoundError(msg)
+            payload = md_path.read_text(encoding="utf-8")
+        payload = cast("str", payload)
+
+        selected_attributes = attributes
+        # TODO: Implement attribute filtering as method of ABC extractor
+
+        if not selected_attributes:
+            msg = "No attributes selected for extraction"
+            logger.warning(msg)
+            raise ValueError(msg)
+
+        context = self._prepare_context(payload=payload, context_type=context_type)
+        annotations: list[GoldStandardAnnotation] = []
+        for attribute in attributes:
+            prompt = attribute.prompt
+            if prompt is None:
+                continue
+            for term in prompt.split():
+                if term.lower().strip() in context:
+                    annotations.extend(
+                        [
+                            GoldStandardAnnotation(
+                                attribute=attribute,
+                                raw_data=True,
+                                annotation_type=AnnotationType.KEYWORD,
+                            )
+                        ]
+                    )
+                    break
+
+        return DocumentExtractionResult(annotations=annotations, messages=[])

--- a/deet/extractors/llm_data_extractor.py
+++ b/deet/extractors/llm_data_extractor.py
@@ -1,20 +1,13 @@
 """Generalisable data extraction module for LLM-based document analysis."""
 
 import json
-from collections.abc import Sequence
-from importlib.resources import files
 from pathlib import Path
-from typing import Annotated, Any, cast
+from typing import Any, cast
 
 import litellm
-import yaml
 from loguru import logger
 from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
     ValidationError,
-    model_validator,
 )
 
 from deet.data_models.base import (
@@ -26,191 +19,25 @@ from deet.data_models.base import (
 )
 from deet.data_models.documents import (
     ContextType,
-    Document,
-    GoldStandardAnnotatedDocument,
 )
 from deet.data_models.extraction import (
     DocumentExtractionResult,
-    ExtractionRunMetadata,
-    ExtractionRunOutput,
 )
-from deet.data_models.ui_schema import UI
-from deet.exceptions import LitellmModelNotMappedError
+from deet.extractors.base_extractor import BaseDataExtractor, DataExtractionConfig
 from deet.settings import (
-    DEFAULT_LLM_MAX_CONTEXT_TOKENS_FALLBACK,
     LLMProvider,
     get_settings,
 )
-from deet.ui.terminal.render import optional_progress
 from deet.utils.tokenisation import (
     count_tokens,
     estimate_cost_usd,
-    get_model_max_tokens,
     truncate_to_token_limit,
 )
 
 settings = get_settings()
 
 
-def default_system_prompt() -> str:
-    """Get default system prompt included in the package."""
-    return (files("deet.prompts") / "system_prompt.txt").read_text()
-
-
-class PromptConfig(BaseModel):
-    """Configuration for prompts used in data extraction."""
-
-    model_config = ConfigDict()
-
-    system_prompt: str | Path = Field(
-        description="System prompt that defines the task and role",
-        default_factory=default_system_prompt,
-    )
-
-    @model_validator(mode="after")
-    def load_system_prompt_file(self) -> "PromptConfig":
-        """Load system prompt from file if Path provided."""
-        if isinstance(self.system_prompt, Path):
-            if not self.system_prompt.exists():
-                sys_prompt_missing = f"sys prompt {self.system_prompt} not found."
-                raise ValueError(sys_prompt_missing)
-            logger.debug(f"Reading system prompt from {self.system_prompt}")
-            self.system_prompt = self.system_prompt.read_text()
-
-        return self
-
-
-def _model_string_for_tokenisation(provider: LLMProvider, model: str) -> str:
-    """
-    Build the model string used for tokenisation.
-
-    Must match how ``LLMDataExtractor`` sets ``self.model`` from config.
-    """
-    match provider:
-        case LLMProvider.AZURE:
-            return f"azure/{model}"
-        case LLMProvider.OLLAMA:
-            return f"ollama/{model}"
-        case _:
-            msg = f"Unsupported LLM provider: {provider}"
-            raise ValueError(msg)
-
-
-class DataExtractionConfig(BaseModel):
-    """Configuration for data extraction tasks."""
-
-    model_config = ConfigDict()
-
-    # LLM
-    provider: Annotated[
-        LLMProvider, UI(help="Choose from a list of supported LLM providers.")
-    ] = Field(default=LLMProvider.AZURE, description="LLM Provider")
-    model: Annotated[str, UI(help="The name of the LLM model you want to use.")] = (
-        Field(
-            default="gpt-4o-mini",
-            description="LLM model identifier used for completions.",
-        )
-    )
-    temperature: float = Field(
-        default=0.1,
-        description="Sampling temperature for the LLM.",
-        ge=0.0,
-    )
-    max_tokens: Annotated[
-        int | None,
-        UI(
-            help=(
-                "The maximum number of tokens in the LLM response. "
-                "Leave blank for the provider default."
-            )
-        ),
-    ] = Field(
-        default=None,
-        description=(
-            "Maximum number of tokens to generate (Leave blank for provider default)."
-        ),
-    )
-
-    max_context_tokens: Annotated[
-        int | None,
-        UI(
-            help=("Maximum input context length " "(Leave blank for provider default).")
-        ),
-    ] = Field(
-        default=None,
-        description=(
-            "Maximum input context length in tokens (system + attributes + "
-            "document). None = infer from model (litellm registry), else "
-            f"{DEFAULT_LLM_MAX_CONTEXT_TOKENS_FALLBACK} via "
-            "DEFAULT_LLM_MAX_CONTEXT_TOKENS_FALLBACK. Override to manage costs."
-        ),
-    )
-
-    # Context
-    default_context_type: Annotated[
-        ContextType, UI(help="Where to extract data from.")
-    ] = Field(
-        default=ContextType.FULL_DOCUMENT, description="Type of context to provide"
-    )
-
-    truncate_on_overflow: Annotated[
-        bool,
-        UI(
-            help=(
-                "Select true to truncate documents longer than max_context_tokens. "
-                "This will ensure extraction runs without crashing, but may mean"
-                " some parts of the document are not seen by the LLM."
-            )
-        ),
-    ] = Field(
-        default=False,
-        description=(
-            "When True, automatically truncate context that exceeds "
-            "max_context_tokens. When False (default), raise ValueError."
-        ),
-    )
-
-    # Prompt
-    prompt_config: PromptConfig = Field(
-        default_factory=PromptConfig, description="Prompt configuration"
-    )
-
-    # Output
-    include_reasoning: bool = Field(
-        default=True, description="Include reasoning in output"
-    )
-    include_additional_text: bool = Field(
-        default=True, description="Include additional text/citations in output"
-    )
-
-    @model_validator(mode="after")
-    def populate_max_context_tokens_from_model(self) -> "DataExtractionConfig":
-        """Populate max_context_tokens from model when not set."""
-        if self.max_context_tokens is not None:
-            return self
-        model_str = _model_string_for_tokenisation(self.provider, self.model)
-        try:
-            inferred = get_model_max_tokens(model_str)
-        except LitellmModelNotMappedError:
-            inferred = None
-        if inferred is not None:
-            self.max_context_tokens = inferred
-        else:
-            # Use shared fallback when model max tokens cannot be inferred.
-            self.max_context_tokens = DEFAULT_LLM_MAX_CONTEXT_TOKENS_FALLBACK
-        return self
-
-    @classmethod
-    def from_yaml(cls, path: Path) -> "DataExtractionConfig":
-        """Load config object from a yaml file."""
-        if not path.exists():
-            not_found = f"Config file not found at: {path}"
-            raise FileNotFoundError(not_found)
-
-        return cls.model_validate(yaml.safe_load(path.read_text()))
-
-
-class LLMDataExtractor:
+class LLMDataExtractor(BaseDataExtractor):
     """
     Generalisable module for LLM-based data extraction from documents.
 
@@ -350,110 +177,6 @@ class LLMDataExtractor:
             model=self.model,
         )
 
-    def extract_from_documents(  # noqa: PLR0913
-        self,
-        attributes: list[Attribute],
-        documents: Sequence[Document],
-        filter_attribute_ids: list[int] | None = None,
-        output_file: Path | None = None,
-        context_type: ContextType | None = None,
-        prompt_outfile: Path | None = None,
-        *,
-        show_progress: bool = False,
-    ) -> ExtractionRunOutput:
-        """
-        Extract data from all documents.
-
-        Loops over documents and extracts data using list of attributes.
-
-        Args:
-            attributes: List of attributes to extract.
-            documents: Sequence of Document instances (required).
-            filter_attribute_ids: Optional list of attribute IDs to filter by.
-            output_file: Optional path to save combined results JSON.
-            context_type: Override config context type; if None, use config default.
-            prompt_outfile: Optional path to write a single JSON object:
-                keys are document IDs, values are prompt payload (messages).
-            show_progress: Whether to show a progress bar.
-
-        Returns:
-            ExtractionRunOutput containing annotated documents and run metadata.
-
-        """
-        if context_type is None:
-            context_type = self.config.default_context_type
-
-        prompt_payloads: dict[str, Any] = {}
-        per_doc_tokens: dict[str, dict[str, int]] = {}
-
-        llm_annotated_docs: list[GoldStandardAnnotatedDocument] = []
-        total_input_tokens = 0
-        total_output_tokens = 0
-        total_cost: float | None = None
-
-        with optional_progress(
-            documents, show_progress=show_progress
-        ) as iterable_documents:
-            for document in iterable_documents:
-                logger.info(f"Processing document: {document.name}")
-
-                if context_type == ContextType.ABSTRACT_ONLY:
-                    document.set_abstract_context()
-                elif context_type == ContextType.FULL_DOCUMENT:
-                    document.context = document.safe_parsed_document.text
-
-                try:
-                    result = self.extract_from_document(
-                        attributes=attributes,
-                        filter_attribute_ids=filter_attribute_ids,
-                        payload=document.context,
-                        context_type=context_type,
-                    )
-
-                    llm_annotated_docs.append(
-                        GoldStandardAnnotatedDocument(
-                            document=document, annotations=result.annotations
-                        )
-                    )
-                    doc_id_str = str(document.safe_identity.document_id)
-                    prompt_payloads[doc_id_str] = result.messages
-                    per_doc_tokens[doc_id_str] = {
-                        "input_tokens": result.input_tokens,
-                        "output_tokens": result.output_tokens,
-                    }
-                    total_input_tokens += result.input_tokens
-                    total_output_tokens += result.output_tokens
-                    if result.total_cost_usd is not None:
-                        total_cost = (total_cost or 0.0) + result.total_cost_usd
-
-                except Exception as e:  # noqa: BLE001
-                    logger.error(f"Failed to process {document.name}: {e}")
-                    logger.debug("Error details", exc_info=True)
-
-        run_metadata = ExtractionRunMetadata(
-            model=self.model,
-            total_input_tokens=total_input_tokens,
-            total_output_tokens=total_output_tokens,
-            total_cost_usd=round(total_cost, 6) if total_cost is not None else None,
-            per_document_tokens=per_doc_tokens,
-        )
-        run_output = ExtractionRunOutput(
-            annotated_documents=llm_annotated_docs,
-            metadata=run_metadata,
-        )
-
-        if output_file is not None:
-            self._save_results(run_output, output_file)
-            logger.info(f"Combined LLM classifications written to: {output_file}")
-
-        if prompt_outfile is not None:
-            prompt_outfile.write_text(
-                json.dumps(prompt_payloads, indent=2), encoding="utf-8"
-            )
-            logger.info(f"Prompt payloads saved to: {prompt_outfile}")
-
-        return run_output
-
     def _write_json_if_path(
         self, data: dict[str, Any] | list[Any], path: Path | None
     ) -> None:
@@ -498,40 +221,6 @@ class LLMDataExtractor:
             f"using filter_ids: {filter_ids}"
         )
         return filtered
-
-    def _prepare_context(
-        self,
-        payload: str,
-        context_type: ContextType | None = None,
-    ) -> str:
-        """Prepare context based on context type."""
-        ctx = (
-            context_type
-            if context_type is not None
-            else self.config.default_context_type
-        )
-        logger.debug(f"Using context type: {ctx}")
-        if ctx == ContextType.FULL_DOCUMENT:
-            context = payload
-            logger.debug(f"Using full document context (length: {len(str(context))})")
-        elif ctx == ContextType.ABSTRACT_ONLY:
-            context = payload
-            logger.debug(f"Using abstract context (length: {len(str(context))})")
-        elif ctx == ContextType.RAG_SNIPPETS:
-            rag_not_impl = "rag-snippets context type is not implemented."
-            raise NotImplementedError(rag_not_impl)
-        elif ctx == ContextType.CUSTOM:
-            custom_not_impl = "custom context type is not implemented."
-            raise NotImplementedError(custom_not_impl)
-        else:
-            other_not_allowed = f"{ctx} context type is not allowed."
-            raise ValueError(other_not_allowed)
-
-        if isinstance(context, list):
-            logger.debug(f"Converting list context to string (items: {len(context)})")
-            context = " ".join(context)
-
-        return context
 
     def _generate_user_message_json(
         self,
@@ -808,22 +497,3 @@ class LLMDataExtractor:
 
         logger.debug(f"Successfully parsed {len(annotations)} annotations")
         return annotations
-
-    def _save_results(
-        self,
-        run_output: ExtractionRunOutput,
-        output_file: Path,
-    ) -> None:
-        """
-        Serialize an ExtractionRunOutput to JSON and write it to disk.
-
-        Args:
-            run_output: The complete extraction run output to persist.
-            output_file: Destination file path.
-
-        """
-        output_file.write_text(
-            run_output.model_dump_json(indent=2),
-            encoding="utf-8",
-        )
-        logger.info(f"Results saved to: {output_file}")

--- a/deet/extractors/semantic_keyword_extractor.py
+++ b/deet/extractors/semantic_keyword_extractor.py
@@ -1,0 +1,104 @@
+"""Generalisable data extraction module for semantic ^keyword-based extraction."""
+
+import re
+from pathlib import Path
+from typing import cast
+
+from loguru import logger
+from sentence_transformers import SentenceTransformer
+from sklearn.metrics.pairwise import cosine_similarity
+
+from deet.data_models.base import AnnotationType, Attribute, GoldStandardAnnotation
+from deet.data_models.documents import (
+    ContextType,
+)
+from deet.data_models.extraction import (
+    DocumentExtractionResult,
+)
+from deet.extractors.base_extractor import BaseDataExtractor, DataExtractionConfig
+
+
+class SemanticKeywordDataExtractor(BaseDataExtractor):
+    """
+    Generalisable module for LLM-based data extraction from documents.
+
+    This module provides a flexible interface for extracting structured data
+    from documents using LLMs, with support for different context types and
+    customizable prompts.
+    """
+
+    def __init__(
+        self,
+        config: DataExtractionConfig,
+    ) -> None:
+        """Initialise, set threshold, and load model."""
+        self.config = config
+        self.similarity_threshold: float = 0.65
+        self.model = SentenceTransformer(config.model)
+
+    def _split_into_sentences(self, text: str) -> list[str]:
+        """Split document into setences."""
+        sentences = re.split(r"(?<=[.!?]) +", text)
+        return [s.strip() for s in sentences if s.strip()]
+
+    def extract_from_document(
+        self,
+        attributes: list[Attribute],
+        filter_attribute_ids: list[int] | None = None,
+        *,
+        payload: str | None = None,
+        md_path: Path | None = None,
+        context_type: ContextType | None = None,
+    ) -> DocumentExtractionResult:
+        """Extract data from a single document."""
+        if (payload is None and md_path is None) or (
+            payload is not None and md_path is not None
+        ):
+            msg = "Exactly one of payload or md_path must be provided"
+            raise ValueError(msg)
+        if md_path is not None:
+            if not md_path.exists():
+                msg = f"Markdown file not found: {md_path}"
+                raise FileNotFoundError(msg)
+            payload = md_path.read_text(encoding="utf-8")
+        payload = cast("str", payload)
+
+        annotations: list[GoldStandardAnnotation] = []
+
+        selected_attributes = attributes
+        # TODO: Implement attribute filtering as method of ABC extractor
+
+        if not selected_attributes:
+            msg = "No attributes selected for extraction"
+            logger.warning(msg)
+            raise ValueError(msg)
+
+        context = self._prepare_context(payload=payload, context_type=context_type)
+        doc_chunks = self._split_into_sentences(context)
+
+        target_phrases = [attr.prompt for attr in attributes]
+
+        chunk_embeddings = self.model.encode(
+            doc_chunks, show_progress_bar=False, convert_to_numpy=True
+        )
+        keyword_embeddings = self.model.encode(
+            target_phrases, show_progress_bar=False, convert_to_numpy=True
+        )
+
+        similarity_matrix = cosine_similarity(keyword_embeddings, chunk_embeddings)
+
+        for attr_idx, attribute in enumerate(attributes):
+            max_sim_score = similarity_matrix[attr_idx].max()
+            if max_sim_score >= self.similarity_threshold:
+                best_match_idx = similarity_matrix[attr_idx].argmax()
+                sentence = doc_chunks[best_match_idx]
+                annotations.append(
+                    GoldStandardAnnotation(
+                        attribute=attribute,
+                        raw_data=True,
+                        annotation_type=AnnotationType.KEYWORD,
+                        reasoning=f"Matches {sentence}, score {max_sim_score:.4f}",
+                    )
+                )
+
+        return DocumentExtractionResult(annotations=annotations, messages=[])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "rapidfuzz>=3.9.0",
     "scikit-learn>=1.7.1",
+    "sentence-transformers>=5.5.1",
     "tabulate>=0.9.0",
     "toml>=0.10.2",
     "typer>=0.21.2",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -317,7 +317,7 @@ def test_extract_happy_path(tmp_path):
     with (
         patch("deet.data_models.project.DeetProject.load") as mock_loader,
         patch("deet.extractors.cli_helpers.run_model_wizard") as mock_wizard,
-        patch("deet.extractors.cli_helpers.LLMDataExtractor") as mock_extractor_cls,
+        patch("deet.extractors.cli_helpers.get_data_extractor") as mock_get_extractor,
         patch("deet.extractors.cli_helpers.continue_after_key"),
         patch("deet.extractors.cli_helpers.console.clear"),
         patch("deet.extractors.cli_helpers.prepare_documents") as mock_prepare,
@@ -330,7 +330,7 @@ def test_extract_happy_path(tmp_path):
         fake_config = DataExtractionConfig()
         mock_wizard.return_value = fake_config
 
-        mock_extractor = mock_extractor_cls.return_value
+        mock_extractor = mock_get_extractor.return_value
         mock_extractor.config = fake_config
         mock_run_output = MagicMock()
         mock_run_output.annotated_documents = mock_processed_data.annotated_documents

--- a/tests/unit/test_extractor_register.py
+++ b/tests/unit/test_extractor_register.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+import pytest
+
+from deet.extractors.base_extractor import (
+    BaseDataExtractor,
+    DataExtractionConfig,
+    ExtractionMethod,
+)
+from deet.extractors.extractor_registry import get_data_extractor
+
+
+@pytest.mark.parametrize("extraction_method", list(ExtractionMethod))
+def test_extraction_methods_return_extractor(extraction_method):
+    """Test that each member of ExtractionMethod returns a valid extractor."""
+    config = DataExtractionConfig(method=extraction_method)
+    with patch("deet.extractors.semantic_keyword_extractor.SentenceTransformer"):
+        extractor = get_data_extractor(config=config)
+    assert isinstance(extractor, BaseDataExtractor)

--- a/tests/unit/test_llm_data_extractor.py
+++ b/tests/unit/test_llm_data_extractor.py
@@ -18,10 +18,9 @@ from deet.data_models.eppi import (
     EppiDocument,
 )
 from deet.data_models.extraction import DocumentExtractionResult, ExtractionRunOutput
+from deet.extractors.base_extractor import DataExtractionConfig, PromptConfig
 from deet.extractors.llm_data_extractor import (
-    DataExtractionConfig,
     LLMDataExtractor,
-    PromptConfig,
 )
 from deet.settings import LLMProvider
 
@@ -149,7 +148,7 @@ def test_prompt_config_missing_file(tmp_path: Path):
 def test_model_validator_populates_max_context_tokens(mock_settings):
     """Test that model_validator sets max_context_tokens from model when None."""
     with patch(
-        "deet.extractors.llm_data_extractor.get_model_max_tokens",
+        "deet.extractors.base_extractor.get_model_max_tokens",
         return_value=128000,
     ):
         config = DataExtractionConfig()
@@ -159,7 +158,7 @@ def test_model_validator_populates_max_context_tokens(mock_settings):
 def test_model_validator_respects_user_override(mock_settings):
     """Test that model_validator does not override explicit max_context_tokens."""
     with patch(
-        "deet.extractors.llm_data_extractor.get_model_max_tokens",
+        "deet.extractors.base_extractor.get_model_max_tokens",
         return_value=128000,
     ):
         config = DataExtractionConfig(max_context_tokens=5000)

--- a/uv.lock
+++ b/uv.lock
@@ -556,7 +556,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
@@ -587,37 +587,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -644,6 +644,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "scikit-learn" },
+    { name = "sentence-transformers" },
     { name = "tabulate" },
     { name = "toml" },
     { name = "typer" },
@@ -693,6 +694,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rapidfuzz", specifier = ">=3.9.0" },
     { name = "scikit-learn", specifier = ">=1.7.1" },
+    { name = "sentence-transformers", specifier = ">=5.5.1" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", specifier = ">=0.21.2" },
@@ -2095,7 +2097,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -2107,7 +2109,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2137,9 +2139,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2151,7 +2153,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3284,6 +3286,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "sentence-transformers"
+version = "5.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "torch" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/d4/7ef93157485e978c016f49da05363c1e4e7237beb5343b64b5631101f0f1/sentence_transformers-5.5.1.tar.gz", hash = "sha256:02b7740dfc60bdbbcb6061625f5d97a5c1a4e2d3baac5f9391b912bb5eae2290", size = 445161, upload-time = "2026-05-20T07:37:44.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/03/ee99a6b030e7a2e056547729f8a4709dd93e13d9c6f07590f74c395c4017/sentence_transformers-5.5.1-py3-none-any.whl", hash = "sha256:4fe11d433badc5282d32f7fc08bc714216b7a5aca426f9df77a45a554756deb7", size = 588887, upload-time = "2026-05-20T07:37:43.004Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Description
Introduces keyword extractors as alternative to llms.

For binary attributes, LLM data extraction may be overkill. With large taxonomies, LLMs may even perform worse than other methods.

Alternative zero-shot approaches to classification include simple keyword matching, and matching on semantic similarity to keywords. Both approaches are implemented here, and can be run using the CLI in the same way as the LLMDataExtractor, by setting the `ExtractionMethod` attribute of the `DataExtractionConfig` object. This is not prompted for in the wizard, but can be run using a config yaml file.

To enable this, extraction logic common to any extractor is moved to an abstract base class. All extractors inherit from this. Each extractor now only has to implement its own `extract_from_document()` function.

## Related Issue(s)
<!-- Link to related issue(s), e.g., "Closes #123" or "Relates to #456" -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [ ] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [x] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing


## Additional Notes

This PR still needs 
- [ ] tests
- [ ] to figure out if any UI changes are required in the CLI
- [ ] updates to the documentation

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
