### PR TITLE
fix: increase CLI speed and introduce test to guard against degradation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
           - "3.12.11"
     if: github.event.pull_request.draft == false
     env:
+      DEET_STARTUP_BUDGET_S: 0.6 # Maximum time deet --help an take before tests break
       UV_CACHE_DIR: /tmp/.uv-cache  # Configure a constant location for the uv cache
     steps:
       - name: Checkout source

--- a/deet/processors/converter_register.py
+++ b/deet/processors/converter_register.py
@@ -3,11 +3,13 @@ A register of supported supported annotation formats
 and a map to their converters.
 """
 
-from enum import StrEnum, auto
+from __future__ import annotations
 
-from deet.processors.base_converter import AnnotationConverter
-from deet.processors.csv_annotation_converter import CSVAnnotationConverter
-from deet.processors.eppi_annotation_converter import EppiAnnotationConverter
+from enum import StrEnum, auto
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deet.processors.base_converter import AnnotationConverter
 
 SUPPORTED_EXTENSIONS: set[str] = {".csv", ".json"}
 
@@ -19,12 +21,22 @@ class SupportedImportFormat(StrEnum):
     GENERIC_CSV = auto()
 
     def get_annotation_converter(self) -> AnnotationConverter:
-        """Return an instance of the parser for the given data type."""
-        return CONVERTER_REGISTRY[self]()
+        """
+        Return an instance of the converter for the given data type.
 
+        Converters are imported lazily here, rather than at module load, because
+        they pull in the heavy document/SDK stack. Keeping this module import-light
+        keeps CLI startup fast for commands that only need the enum.
+        """
+        from deet.processors.csv_annotation_converter import (
+            CSVAnnotationConverter,
+        )
+        from deet.processors.eppi_annotation_converter import (
+            EppiAnnotationConverter,
+        )
 
-# Registry mapping
-CONVERTER_REGISTRY = {
-    SupportedImportFormat.EPPI_JSON: EppiAnnotationConverter,
-    SupportedImportFormat.GENERIC_CSV: CSVAnnotationConverter,
-}
+        registry: dict[SupportedImportFormat, type[AnnotationConverter]] = {
+            SupportedImportFormat.EPPI_JSON: EppiAnnotationConverter,
+            SupportedImportFormat.GENERIC_CSV: CSVAnnotationConverter,
+        }
+        return registry[self]()

--- a/tests/unit/test_startup_performance.py
+++ b/tests/unit/test_startup_performance.py
@@ -1,0 +1,50 @@
+"""
+Regression guard for CLI startup time.
+
+Keeping ``deet --help`` fast requires careful attention to lazy loading.
+
+This test guards against degradation of startup time
+by spawning a cold interpreter (so it measures real import cost, which an
+in-process CliRunner would not), and takes the best of several runs to limit
+scheduling/cache noise. The budget can be relaxed for slow environments via the
+``DEET_STARTUP_BUDGET_S`` environment variable
+"""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STARTUP_BUDGET_S = float(os.environ.get("DEET_STARTUP_BUDGET_S", "0.5"))
+MEASURED_RUNS = 3
+
+
+def _time_help_invocation() -> float:
+    """Run ``deet --help`` in a fresh interpreter and return wall-clock seconds."""
+    start = time.perf_counter()
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-m", "deet.scripts.cli", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    elapsed = time.perf_counter() - start
+    # Guard against measuring a fast crash instead of a working --help.
+    assert result.returncode == 0, result.stderr
+    assert "Usage" in result.stdout
+    return elapsed
+
+
+def test_deet_help_starts_within_budget() -> None:
+    _time_help_invocation()  # warm-up: prime bytecode cache / filesystem cache
+    best = min(_time_help_invocation() for _ in range(MEASURED_RUNS))
+    assert best < STARTUP_BUDGET_S, (
+        f"`deet --help` cold start took {best:.2f}s, over the "
+        f"{STARTUP_BUDGET_S:.2f}s budget. A heavy import was probably added to the "
+        f"startup path -- profile with "
+        f"`python -X importtime -m deet.scripts.cli`. If the environment is simply "
+        f"slow, relax the budget via the DEET_STARTUP_BUDGET_S env var."
+    )


### PR DESCRIPTION
# Pull Request

## Description

`deet --help` took more than 1 second due to insufficient lazy loading. Users remarked that they didn't know whether something was happening when running `deet project init` (also > 1 second).

This PR moves the converter registry inside `get_annotation_converter()` to prevent over-eager loading of documents -> destiny_sdk > etc.

It also introduces a test to prevent future changes from slowing the CLI down again

## Related Issue(s)

Closes #220, closes #295

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [x] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
Introduces a regression test for speed. Continues to pass all other tests, including integration tests.

## Additional Notes


---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
