### PR TITLE
feat: add CLI option to specify custom prompt location

### DIFF
--- a/deet/extractors/cli_helpers.py
+++ b/deet/extractors/cli_helpers.py
@@ -146,8 +146,9 @@ def prepare_documents(
     return None
 
 
-def run_extraction_pipeline(
+def run_extraction_pipeline(  # noqa: PLR0913
     typer_context: typer.Context,
+    prompt_csv_path: Path | None,
     config_path: Path | None = None,
     prompt_population: (
         CustomPromptPopulationMethod | None
@@ -167,8 +168,15 @@ def run_extraction_pipeline(
     experiment_artefacts = init_extraction_run(deet_project.experiments_dir, run_name)
 
     if prompt_population is not None:
+        if (
+            prompt_population == CustomPromptPopulationMethod.FILE
+            and prompt_csv_path is not None
+            and not prompt_csv_path.exists()
+        ):
+            fail_with_message(f"Prompt csv {prompt_csv_path} cannot be found")
         processed_annotation_data.populate_custom_prompts(
-            method=prompt_population, filepath=deet_project.prompt_csv_path
+            method=prompt_population,
+            filepath=prompt_csv_path or deet_project.prompt_csv_path,
         )
         if not processed_annotation_data.attributes:
             fail_with_message(

--- a/deet/scripts/commands/experiments.py
+++ b/deet/scripts/commands/experiments.py
@@ -16,39 +16,57 @@ app = typer.Typer(
     )
 )
 
+# Shared options
+ConfigPathOption = Annotated[
+    Path | None,
+    typer.Option(
+        help="A path to a config file containing options for data "
+        "extraction configuration. A template with defaults is generated"
+        " on project setup."
+        "\nLeave this blank to configure interactively."
+    ),
+]
+
+PromptPopulationOption = Annotated[
+    CustomPromptPopulationMethod | None,
+    typer.Option(
+        help="A method to define custom prompts for your attributes to be "
+        "extracted. Leave blank to use the prompts in your gold standard "
+        "data. Set to `file` to provide a file of prompt definitions "
+        "(make sure this is supplied below). Set to `cli` to define prompts"
+        " interactively in the CLI. With `file`, only attributes that appear "
+        "in the CSV with a non-empty `prompt` are kept for extraction and "
+        "evaluation (see also `--csv-path`)."
+    ),
+]
+
+RunNameOption = Annotated[
+    str,
+    typer.Option(
+        help="A name for the run (which will appended to a timestamp) "
+        "to help you identify this run later"
+    ),
+]
+
+PromptLocationOption = Annotated[
+    Path | None,
+    typer.Option(
+        help=(
+            "A custom location of a csv file to read prompts from"
+            " (if not default project location)"
+        )
+    ),
+]
+
 
 @app.command()
 @project_required
-def evaluate(
+def evaluate(  # noqa: PLR0913
     typer_context: typer.Context,
-    config_path: Annotated[
-        Path | None,
-        typer.Option(
-            help="A path to a config file containing options for data "
-            "extraction configuration. A template with defaults is generated"
-            " on project setup."
-            "\nLeave this blank to configure interactively."
-        ),
-    ] = None,
-    prompt_population: Annotated[
-        CustomPromptPopulationMethod | None,
-        typer.Option(
-            help="A method to define custom prompts for your attributes to be "
-            "extracted. Leave blank to use the prompts in your gold standard "
-            "data. Set to `file` to provide a file of prompt definitions "
-            "(make sure this is supplied below). Set to `cli` to define prompts"
-            " interactively in the CLI. With `file`, only attributes that appear "
-            "in the CSV with a non-empty `prompt` are kept for extraction and "
-            "evaluation (see also `--csv-path`)."
-        ),
-    ] = CustomPromptPopulationMethod.FILE,
-    run_name: Annotated[
-        str,
-        typer.Option(
-            help="A name for the run (which will appended to a timestamp) "
-            "to help you identify this run later"
-        ),
-    ] = "",
+    config_path: ConfigPathOption = None,
+    prompt_population: PromptPopulationOption = CustomPromptPopulationMethod.FILE,
+    prompt_csv_path: PromptLocationOption = None,
+    run_name: RunNameOption = "",
     custom_evaluation_metrics: Annotated[
         list[str] | None,
         typer.Option(
@@ -73,6 +91,7 @@ def evaluate(
     run_output, processed_annotation_data, experiment_artefacts = (
         run_extraction_pipeline(
             typer_context=typer_context,
+            prompt_csv_path=prompt_csv_path,
             config_path=config_path,
             prompt_population=prompt_population,
             run_name=run_name,
@@ -94,36 +113,12 @@ def evaluate(
 
 @app.command()
 @project_required
-def predict(
+def predict(  # noqa: PLR0913
     typer_context: typer.Context,
-    config_path: Annotated[
-        Path | None,
-        typer.Option(
-            help="A path to a config file containing options for data "
-            "extraction configuration. A template with defaults is generated"
-            " on project setup."
-            "\nLeave this blank to configure interactively."
-        ),
-    ] = None,
-    prompt_population: Annotated[
-        CustomPromptPopulationMethod | None,
-        typer.Option(
-            help="A method to define custom prompts for your attributes to be "
-            "extracted. Leave blank to use the prompts in your gold standard "
-            "data. Set to `file` to provide a file of prompt definitions "
-            "(make sure this is supplied below). Set to `cli` to define prompts"
-            " interactively in the CLI. With `file`, only attributes that appear "
-            "in the CSV with a non-empty `prompt` are kept for extraction and "
-            "evaluation (see also `--csv-path`)."
-        ),
-    ] = CustomPromptPopulationMethod.FILE,
-    run_name: Annotated[
-        str,
-        typer.Option(
-            help="A name for the run (which will appended to a timestamp) "
-            "to help you identify this run later"
-        ),
-    ] = "",
+    config_path: ConfigPathOption = None,
+    prompt_population: PromptPopulationOption = CustomPromptPopulationMethod.FILE,
+    prompt_csv_path: PromptLocationOption = None,
+    run_name: RunNameOption = "",
     ignore_references: bool = typer.Option(  # noqa: FBT001
         default=False,
         help=(
@@ -145,6 +140,7 @@ def predict(
     (run_output, processed_annotation_data, experiment_artefacts) = (
         run_extraction_pipeline(
             typer_context=typer_context,
+            prompt_csv_path=prompt_csv_path,
             config_path=config_path,
             prompt_population=prompt_population,
             run_name=run_name,

--- a/docs/setup/quickstart.md
+++ b/docs/setup/quickstart.md
@@ -156,6 +156,14 @@ Now that you've defined your prompts, you are ready to extract data from your do
     Running `deet experiments evaluate` will create a folder in your project's
     `data-extraction-experiments` directory, run the data extraction pipeline,
     and save the results of that experiment to the newly created folder.
+    It will also save a snapshot of the prompts you used, as well as the config you used,
+    making it easy to reproduce your experiments.
+    If you wish to use prompts from a different location than the default location
+    for your project, you can run an experiment with the `--prompt-csv-path` option, e.g.
+
+    ```sh
+    deet experiments evaluate --prompt-csv-path my-custom-prompts.csv
+    ```
 
 - **Python**
 


### PR DESCRIPTION
# Pull Request

## Description

DeetProject.prompt_csv defines an expected location of a prompt csv file. Each version of this is snapshotted in an experiment directory, but some users prefer to have multiple versions of prompts (e.g. with different attribute sets) that they swap between from run to run.

This adds a  `prompt_csv_path` to the `evaluate` and `predict` commands, which allows users to override the default with a path to a specific prompt csv.

It also updates the docs to refer to this.

It also moves argument definitions shared between evaluate and predict into a single shared definition.

## Related Issue(s)
Closes #298 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [x] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing


## Additional Notes

---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
