### PR TITLE
feat: added command deet project edit

### DIFF
--- a/deet/scripts/commands/project.py
+++ b/deet/scripts/commands/project.py
@@ -20,6 +20,7 @@ from deet.scripts.project_utils import (
     create_project,
     guard_overwrite,
     prompt_name,
+    run_edit,
 )
 from deet.scripts.typer_context import project_required
 from deet.settings import LogLevel
@@ -83,6 +84,26 @@ def new(
     create_project(
         target, name, data_path=data_path, data_type=data_type, pdf_dir=pdf_dir
     )
+
+
+@app.command()
+@project_required
+def edit(
+    typer_context: typer.Context,
+    field: Annotated[
+        str | None,
+        typer.Argument(help="Optionally edit a single field instead of all of them."),
+    ] = None,
+) -> None:
+    """
+    Edit an existing project's configuration.
+
+    Re-collects the project fields (pre-filled with the current values) and rewrites
+    ``project.yaml`` WITHOUT regenerating artefacts (prompt CSV, link map, experiment
+    dirs). Pass a field name to edit just that field; the full edit also lets you
+    update credentials.
+    """
+    run_edit(typer_context.obj.project, field)
 
 
 @app.command()

--- a/deet/scripts/project_utils.py
+++ b/deet/scripts/project_utils.py
@@ -2,11 +2,14 @@
 """CLI helpers for the ``deet project`` setup/creation commands."""
 
 from pathlib import Path
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
+
+if TYPE_CHECKING:
+    from deet.data_models.project import DeetProject
 
 import typer
 from InquirerPy import inquirer
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from deet.processors.converter_register import SupportedImportFormat
 from deet.settings import DataExtractionSettings, LogLevel
@@ -40,12 +43,7 @@ def run_init_wizard(root: Path, name: str) -> None:
     project.anchor_to(root)
     project.setup()
 
-    console.clear()
-    configure_env_md = render_template("project/configure_env.md")
-    console.print(info_panel(configure_env_md, ":key: Credential management"))
-    continue_after_key()
-    settings = run_model_wizard(DataExtractionSettings)
-    settings.dump_to_env(target_path=root / ".env")
+    _configure_credentials(root / ".env")
 
     new_directory = root.relative_to(Path.cwd())
 
@@ -140,6 +138,104 @@ def prompt_name() -> str:
     console.clear()
     console.print(wizard_field_help("name", ui_help))
     return str(inquire_pydantic_field(DeetProject, "name", info, ui))
+
+
+def _configure_credentials(env_path: Path) -> None:
+    """
+    Run the credentials wizard, writing to the given ``.env``.
+
+    Used by both ``init``/``new`` (first-time setup) and ``edit``. Secrets left
+    unchanged come back as ``None`` from the wizard, which ``dump_to_env`` skips, so
+    existing ``.env`` values are preserved.
+    """
+    console.clear()
+    console.print(
+        info_panel(
+            render_template("project/configure_env.md"), ":key: Credential management"
+        )
+    )
+    continue_after_key()
+
+    settings = run_model_wizard(DataExtractionSettings)
+    settings.dump_to_env(target_path=env_path)
+
+
+def _editable_field_names(model: type[BaseModel]) -> list[str]:
+    """Return the model's wizard-editable field names (those with UI metadata)."""
+    return [
+        name
+        for name, info in model.model_fields.items()
+        if get_ui_metadata(info) is not None
+    ]
+
+
+def _project_display_defaults(project: "DeetProject") -> dict[str, str]:
+    """
+    Build display-ready, editable defaults for the edit wizard.
+
+    Paths are absolute so they stay correct when edit runs from a subdirectory;
+    they are re-relativised against the project root by ``anchor_to`` afterwards.
+    """
+    pdf_abspath = project.pdf_dir_abspath
+    return {
+        "name": project.name,
+        "gold_standard_data_format": project.gold_standard_data_format.value,
+        "gold_standard_data_path": str(project.gold_standard_data_abspath),
+        "pdf_dir": str(pdf_abspath) if pdf_abspath is not None else "",
+    }
+
+
+def run_edit(project: "DeetProject", field: str | None) -> None:
+    """
+    Re-collect a project's fields (pre-filled) and rewrite ``project.yaml``.
+
+    Does NOT run ``setup()``, so existing artefacts (prompt CSV, link map, experiment
+    dirs) are preserved. ``field`` edits a single field; otherwise the full wizard
+    runs and credentials may be updated too.
+    """
+    from deet.data_models.project import DeetProject
+
+    original_data_path = project.gold_standard_data_path
+    original_format = project.gold_standard_data_format
+    display = _project_display_defaults(project)
+
+    if field is None:
+        updated = run_model_wizard(DeetProject, defaults=display)
+    else:
+        info = DeetProject.model_fields.get(field)
+        ui = get_ui_metadata(info) if info is not None else None
+        if info is None or ui is None:
+            editable = ", ".join(_editable_field_names(DeetProject))
+            fail_with_message(
+                f"'{field}' is not an editable field. Choose one of: {editable}."
+            )
+        console.clear()
+        console.print(wizard_field_help(field, ui.help))
+        new_value = inquire_pydantic_field(
+            DeetProject, field, info, ui, default_override=display[field]
+        )
+        updated = DeetProject.model_validate({**display, field: new_value})
+
+    updated.anchor_to(project.root)
+    updated.created_at = project.created_at
+    updated.dump_to_yaml()
+
+    if field is None:
+        _configure_credentials(project.root / ".env")
+
+    if (
+        updated.gold_standard_data_path != original_data_path
+        or updated.gold_standard_data_format != original_format
+    ):
+        notify(
+            "Gold-standard data source changed. The prompt CSV and link map were "
+            "generated from the previous data and may now be stale -- regenerate them"
+            " with `deet project regenerate-prompt-csv` and"
+            " `deet project regenerate-link-map` if needed.",
+            level=LogLevel.WARNING,
+        )
+
+    notify(f"Project '{updated.name}' updated.", level=LogLevel.SUCCESS)
 
 
 # Shared options, so `init` and `new` accept identical headless arguments.

--- a/deet/ui/terminal/wizards.py
+++ b/deet/ui/terminal/wizards.py
@@ -148,9 +148,19 @@ def get_ui_metadata(field_info: FieldInfo) -> UI | None:
 
 
 def inquire_pydantic_field(
-    model_class: type[BaseModel], field_name: str, field_info: FieldInfo, ui: UI
+    model_class: type[BaseModel],
+    field_name: str,
+    field_info: FieldInfo,
+    ui: UI,
+    default_override: str | None = None,
 ) -> str | bool | None:
-    """Prompt user to provide data for pydantic field."""
+    """
+    Prompt user to provide data for pydantic field.
+
+    ``default_override`` (a display-ready string: a path, an enum value, or "" for
+    an unset optional) replaces the field's own default when supplied, so callers
+    can pre-fill the current value while still prompting (e.g. ``deet project edit``).
+    """
 
     def pydantic_validate(answer: str) -> bool | str:
         is_optional = type(None) in get_args(field_info.annotation)
@@ -165,7 +175,9 @@ def inquire_pydantic_field(
         else:
             return True
 
-    default = field_info.get_default()
+    default = (
+        default_override if default_override is not None else field_info.get_default()
+    )
     default = "" if default in (PydanticUndefined, None) else default
 
     widget_args: dict[str, Any] = {
@@ -186,7 +198,10 @@ def inquire_pydantic_field(
 
 
 def run_model_wizard[T: BaseModel](
-    model_class: type[T], *, prefill: dict[str, object] | None = None
+    model_class: type[T],
+    *,
+    prefill: dict[str, object] | None = None,
+    defaults: dict[str, str] | None = None,
 ) -> T:
     """
     Create a wizard from a pydantic model.
@@ -194,8 +209,13 @@ def run_model_wizard[T: BaseModel](
     Fields present in ``prefill`` are not prompted for; their values are injected
     into the model directly. This lets a caller supply a field (e.g. the project
     name derived from a directory) instead of asking the user for it.
+
+    ``defaults`` maps a field name to a display-ready string shown as that field's
+    editable default, so a caller can pre-fill current values while still prompting
+    (e.g. ``deet project edit``).
     """
     prefill = prefill or {}
+    defaults = defaults or {}
     answers: dict[str, object] = {}
     ui_steps: list[tuple[str, FieldInfo, UI]] = []
     for name, info in model_class.model_fields.items():
@@ -210,7 +230,9 @@ def run_model_wizard[T: BaseModel](
         console.print(wizard_header(model_class.__name__, i, total_steps))
         console.print(wizard_field_help(f_name, f_ui.help))
 
-        answers[f_name] = inquire_pydantic_field(model_class, f_name, f_info, f_ui)
+        answers[f_name] = inquire_pydantic_field(
+            model_class, f_name, f_info, f_ui, default_override=defaults.get(f_name)
+        )
 
     answers.update(prefill)
     return model_class.model_validate(answers)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -298,6 +298,113 @@ def test_new_project_headless_with_args():
         mock_wizard.assert_not_called()
 
 
+def _wizard_result_like(project):
+    """Build a MagicMock standing in for a wizard-produced project."""
+    updated = MagicMock(spec=DeetProject)
+    updated.name = project.name
+    updated.gold_standard_data_format = project.gold_standard_data_format
+    updated.gold_standard_data_path = project.gold_standard_data_path
+    return updated
+
+
+def test_edit_project_full_writes_yaml_without_setup(
+    valid_project_data, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    project = DeetProject(**valid_project_data)
+    updated = _wizard_result_like(project)
+    settings_out = MagicMock(spec=DataExtractionSettings)
+    settings_out.azure_api_key = None
+    settings_out.azure_api_base = None
+
+    with (
+        patch("deet.data_models.project.DeetProject.load", return_value=project),
+        patch(
+            "deet.scripts.project_utils.run_model_wizard",
+            side_effect=[updated, settings_out],
+        ) as mock_wizard,
+        patch("deet.scripts.project_utils.continue_after_key"),
+        patch("deet.scripts.project_utils.console.clear"),
+    ):
+        result = runner.invoke(app, ["project", "edit"])
+
+    assert result.exit_code == 0
+    assert mock_wizard.call_count == 2  # project fields + credentials
+    updated.anchor_to.assert_called_once_with(project.root)
+    assert updated.created_at == project.created_at  # preserved, not reset
+    updated.dump_to_yaml.assert_called_once()
+    updated.setup.assert_not_called()  # artefacts NOT regenerated
+    # credentials are written to the project's own .env
+    settings_out.dump_to_env.assert_called_once_with(target_path=tmp_path / ".env")
+
+
+def test_edit_single_field_only_prompts_that_field(
+    valid_project_data, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    project = DeetProject(**valid_project_data)
+    updated = _wizard_result_like(project)
+
+    with (
+        patch("deet.data_models.project.DeetProject.load", return_value=project),
+        patch(
+            "deet.scripts.project_utils.inquire_pydantic_field",
+            return_value="new_pdfs",
+        ),
+        patch(
+            "deet.data_models.project.DeetProject.model_validate", return_value=updated
+        ) as mock_validate,
+        patch("deet.scripts.project_utils.run_model_wizard") as mock_wizard,
+        patch("deet.scripts.project_utils.console.clear"),
+    ):
+        result = runner.invoke(app, ["project", "edit", "pdf_dir"])
+
+    assert result.exit_code == 0
+    mock_wizard.assert_not_called()
+    updated.dump_to_yaml.assert_called_once()
+    updated.setup.assert_not_called()
+    merged = mock_validate.call_args.args[0]
+    assert merged["pdf_dir"] == "new_pdfs"
+
+
+def test_edit_rejects_unknown_field(valid_project_data, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    project = DeetProject(**valid_project_data)
+
+    with patch("deet.data_models.project.DeetProject.load", return_value=project):
+        result = runner.invoke(app, ["project", "edit", "bogus"])
+
+    assert result.exit_code == 1
+    assert "not an editable field" in result.stderr
+
+
+def test_edit_warns_when_data_source_changes(valid_project_data, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    project = DeetProject(**valid_project_data)
+    updated = _wizard_result_like(project)
+    updated.gold_standard_data_path = Path("different.json")  # changed
+    settings_out = MagicMock(spec=DataExtractionSettings)
+    settings_out.azure_api_key = None
+    settings_out.azure_api_base = None
+
+    with (
+        patch("deet.data_models.project.DeetProject.load", return_value=project),
+        patch(
+            "deet.scripts.project_utils.run_model_wizard",
+            side_effect=[updated, settings_out],
+        ),
+        patch("deet.scripts.project_utils.notify") as mock_notify,
+        patch("deet.scripts.project_utils.continue_after_key"),
+        patch("deet.scripts.project_utils.console.clear"),
+    ):
+        result = runner.invoke(app, ["project", "edit"])
+
+    assert result.exit_code == 0
+    assert any(
+        "regenerate" in str(call.args[0]).lower() for call in mock_notify.call_args_list
+    )
+
+
 def test_init_project_noninteractive(tmp_path):
     data_file = tmp_path / "references.json"
     data_file.touch()

--- a/tests/unit/test_ui/test_wizards.py
+++ b/tests/unit/test_ui/test_wizards.py
@@ -61,6 +61,27 @@ def test_run_model_wizard_filters_fields(mock_inquire):
     assert result.auto_field == 25
 
 
+@patch("deet.ui.terminal.wizards.inquire_pydantic_field")
+def test_run_model_wizard_threads_defaults(mock_inquire):
+    """`defaults` are passed through as each field's editable default override."""
+    mock_inquire.return_value = "test-str"
+
+    run_model_wizard(SampleModel, defaults={"str_field": "current value"})
+
+    _, kwargs = mock_inquire.call_args
+    assert kwargs["default_override"] == "current value"
+
+
+@patch("deet.ui.terminal.wizards.inquire_pydantic_field")
+def test_run_model_wizard_default_override_none_without_defaults(mock_inquire):
+    mock_inquire.return_value = "test-str"
+
+    run_model_wizard(SampleModel)
+
+    _, kwargs = mock_inquire.call_args
+    assert kwargs["default_override"] is None
+
+
 def test_get_ui_metadata():
     str_field = SampleModel.model_fields["str_field"]
     auto_field = SampleModel.model_fields["auto_field"]


### PR DESCRIPTION
# Pull Request

## Description
Users want to be able to edit information entered on project creation via a wizard, without creating a new project and overwriting project artefacts.

This PR adds the command `deet project edit`, which runs the project wizard again, populating defaults with the existing information. On completion, it does not create a prompt definition csv or link map, to avoid overwriting anything.

The command can also be run with a field name, e.g. `deet project edit pdf_dir` to edit a single field.

## Related Issue(s)

Closes #297 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement/modification to existing feature
- [ ] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [x] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
See new tests added

## Additional Notes


---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
