### PR TITLE
Docs/296 documentation fixes

### DIFF
--- a/deet/data_models/documents.py
+++ b/deet/data_models/documents.py
@@ -41,11 +41,11 @@ from deet.utils.identifier_utils import (
 class ContextType(StrEnum):
     """Types of context that can be provided to the LLM."""
 
-    EMPTY = auto()
+    # TODO: implement EMPTY = auto()
     FULL_DOCUMENT = auto()
     ABSTRACT_ONLY = auto()
-    RAG_SNIPPETS = auto()
-    CUSTOM = auto()
+    # TODO: RAG_SNIPPETS = auto()
+    # TODO: CUSTOM = auto()
 
 
 class DocumentIDSource(StrEnum):
@@ -302,7 +302,7 @@ class Document(BaseModel):
     name: str
     citation: ReferenceFileInput
     context: str | None = None  # new defaults, empty
-    context_type: ContextType | None = ContextType.EMPTY
+    context_type: ContextType | None = None
     document_id: int | str | None = None  # add support for str ids, e.g. uuid
     document_identity: DocumentIdentity | None = None
 
@@ -372,10 +372,8 @@ class Document(BaseModel):
             if self.context is None:
                 no_context_err = base_err_msg + "`context` is empty."
                 raise ValueError(no_context_err)
-            if self.context_type is None or self.context_type == ContextType.EMPTY:
-                bad_context_type_err = (
-                    base_err_msg + "`context_type` musnt be None or EMPTY."
-                )
+            if self.context_type is None:
+                bad_context_type_err = base_err_msg + "`context_type` musnt be None."
                 raise ValueError(bad_context_type_err)
             if self.document_identity is None:
                 no_doc_id_err = (

--- a/deet/data_models/project.py
+++ b/deet/data_models/project.py
@@ -89,7 +89,7 @@ class DeetProject(BaseModel):
                 "If you want to extract data from full texts, "
                 "choose a directory that contains your pdfs."
                 " You will have an opportunity to link this later"
-                " by running `deet project link`"
+                " using a 'link map' created here"
             )
         ),
     ] = Field(None, description="Path to folder containing PDFs")

--- a/deet/data_models/project.py
+++ b/deet/data_models/project.py
@@ -89,7 +89,7 @@ class DeetProject(BaseModel):
                 "If you want to extract data from full texts, "
                 "choose a directory that contains your pdfs."
                 " You will have an opportunity to link this later"
-                " by running `deet link-documents-fulltexts`"
+                " by running `deet project link`"
             )
         ),
     ] = Field(None, description="Path to folder containing PDFs")

--- a/deet/extractors/llm_data_extractor.py
+++ b/deet/extractors/llm_data_extractor.py
@@ -517,12 +517,6 @@ class LLMDataExtractor:
         elif ctx == ContextType.ABSTRACT_ONLY:
             context = payload
             logger.debug(f"Using abstract context (length: {len(str(context))})")
-        elif ctx == ContextType.RAG_SNIPPETS:
-            rag_not_impl = "rag-snippets context type is not implemented."
-            raise NotImplementedError(rag_not_impl)
-        elif ctx == ContextType.CUSTOM:
-            custom_not_impl = "custom context type is not implemented."
-            raise NotImplementedError(custom_not_impl)
         else:
             other_not_allowed = f"{ctx} context type is not allowed."
             raise ValueError(other_not_allowed)

--- a/deet/scripts/commands/project.py
+++ b/deet/scripts/commands/project.py
@@ -217,6 +217,17 @@ def link(typer_context: typer.Context) -> None:
         )
         linked_document.save(file_path)
 
+    # TODO: Nice message explaining what happened
+    console.print(
+        info_panel(
+            render_template(
+                "project/linked",
+                linked_documents=linked_documents,
+                documents=processed_annotation_data.documents,
+            )
+        )
+    )
+
 
 @app.command()
 def test_llm_config(

--- a/deet/ui/terminal/templates/help_text.py
+++ b/deet/ui/terminal/templates/help_text.py
@@ -13,7 +13,7 @@ APP_HELP = flow("""
     run `deet project --help` for information on commands to create and configure
     a project.
 
-    run `deet run --help` for information on commands to extract data
+    run `deet experiments --help` for information on commands to extract data
 
     Prefix any command with --verbose to see complete log output.
 

--- a/deet/ui/terminal/templates/project/configure_env.md
+++ b/deet/ui/terminal/templates/project/configure_env.md
@@ -1,5 +1,7 @@
 ## Let's store your API keys
 
-We will now collect your credentials and save them to a .env file in your current directory.
+We will now collect credentials for accessing LLMs via Azure and save them to a .env file in your current directory.
 
 Make sure you do not commit or otherwise share this file publicly!
+
+If you do not wish to use Azure, you can run deet on local models via [ollama](https://ollama.com/). If so, leave the following blank.

--- a/deet/ui/terminal/templates/project/linked.md
+++ b/deet/ui/terminal/templates/project/linked.md
@@ -1,0 +1,5 @@
+## Document linking successful
+
+{{linked_documents|length}} out of {{documents|length}} have been successfully linked.
+
+The project's linked_documents folder contains a representation of each document with the parsed content from the linked files.

--- a/deet/ui/terminal/templates/project/success.md
+++ b/deet/ui/terminal/templates/project/success.md
@@ -30,5 +30,5 @@ If you prefer to skip the wizard, edit the config file `{{project.config_path}}`
 and pass this as a command line argument
 
 ```sh
-deet run --config-path {{project.config_path}} extract
+deet experiments evaluate --config-path {{project.config_path}} extract
 ```

--- a/docs/concepts/data-extraction.md
+++ b/docs/concepts/data-extraction.md
@@ -80,20 +80,29 @@ attributes = [
 
 String attributes describe data extraction elements that can be represented as texts. For example, a string attribute could be used to extract the location of a study
 
+!!! Warning "Not fully supported"
+    string attributes are only partially covered by standard evaluation metrics
+
 ### float
 
 Float attributes describe any type of numeric data extraction elements, such as the average age of study participants, or the effect size or standard error.
 
+!!! Warning "Not fully supported"
+    float attributes are only partially covered by standard evaluation metrics
+
 ### integer
 
 Integer attributes describe the subset of numeric data extraction elements that can be represented by whole numbers, and whole numbers only, for example, the number of participants in a trial, or the year in which a trial was carried out.
+
+!!! Warning "Not fully supported"
+    integer attributes are only partially covered by standard evaluation metrics
 
 ### list
 
 Lists describe data extraction elements that have 0, 1, or more elements. For example, the prompt "extract all of the health outcomes described in the study" could be represented as a list
 
 !!! Warning "Not fully supported"
-    List attributes are not reliably parsed from EppiJson, and are not covered by currently implemented standard evaluation metrics
+    List attributes are not covered by currently implemented standard evaluation metrics
 
 ### dict
 

--- a/docs/setup/installation.md
+++ b/docs/setup/installation.md
@@ -270,7 +270,9 @@ pre-commit install
 `deet` reads general settings from a `.env` file within the directory you are running it from.
 Settings will be set to default values if this file does not exist, but if you want to use deet with azure models (default behaviour), you will need to provide a set of credentials.
 
-To do this, open a file called `.env` in the directory you are running `deet`, and add the following lines, replacing the placeholders with your own credentials:
+If you are using the CLI, you will be prompted to enter this information
+
+Otherwise, open a file called `.env` in the directory you are running `deet`, and add the following lines, replacing the placeholders with your own credentials:
 
 ```sh
 AZURE_API_KEY="your-azure-api-key-here"

--- a/docs/setup/quickstart.md
+++ b/docs/setup/quickstart.md
@@ -129,7 +129,7 @@ Once you are happy with this file, you can link the documents
 ### Writing and editing prompts
 
 Setting up a project creates a file called `prompts/prompt_definitions.csv` with a row for each of the attributes you can extract from your data.
-Edit this file, creating a prompt in the `prompt` column.
+Edit this file, creating a prompt in the `prompt` column. This can contain any text, including commas.
 Leave the `prompt` column blank for any attribute you do not wish to extract.
 You can also edit the `output_data_type` column ([more info](../concepts/data-extraction.md#attributes)) if the automatically parsed data type is incorrect.
 

--- a/docs/setup/quickstart.md
+++ b/docs/setup/quickstart.md
@@ -131,7 +131,7 @@ Once you are happy with this file, you can link the documents
 Setting up a project creates a file called `prompts/prompt_definitions.csv` with a row for each of the attributes you can extract from your data.
 Edit this file, creating a prompt in the `prompt` column.
 Leave the `prompt` column blank for any attribute you do not wish to extract.
-You can also edit the `output_data_type` column (see [deet.data_models.base.AttributeType](../reference/api.md#deet.data_models.base.AttributeType)) if the automatically parsed data type is incorrect.
+You can also edit the `output_data_type` column ([more info](../concepts/data-extraction.md#attributes)) if the automatically parsed data type is incorrect.
 
 {{ read_csv('examples/quickstart/prompts/prompt_definitions.csv') }}
 

--- a/docs/setup/quickstart.md
+++ b/docs/setup/quickstart.md
@@ -75,9 +75,13 @@ This is where we will store configuration options and the results of your data e
 
 ### Linking documents to pdfs
 
-If you want to extract data from the full texts of your documents, you will need to edit the file `link_map.csv` created in your project directory by setting up deet, to point each document to the file that contains its pdf.
-On initialising a project, this is pre-filled with plausible mappings, but you should check that these are correct
+If you want to extract data from the full texts of your documents, you will need to edit the file `link_map.csv` created in your project directory by setting up deet, to point each document to the file that contains its pdf. The name of the file should be entered in the `file_path` column.
+
+On initialising a project, this columnn is pre-filled with plausible mappings, but you should check that these are correct
 and add any missing paths yourself.
+
+??? note "External and internal IDs"
+    Note that `deet` uses the `document_id` field internally. Where imported documents have an id that is not compatible, this is preserved in `external_id`, and converted to a compatible `document_id`. Where external IDs are compatible, these fields will be identical.
 
 {{ read_csv('examples/quickstart/link_map.csv') }}
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -724,20 +724,6 @@ def test_document_creation() -> None:
     assert doc.context == "This is test content"
 
 
-def test_document_creation_with_list_context() -> None:
-    """Test creating a document with context as string (list joined)."""
-    citation = ReferenceFileInput()
-    context_str = "Paragraph 1\n\nParagraph 2"
-    doc = Document(
-        name="Test Document 2",
-        citation=citation,
-        context=context_str,
-        context_type=ContextType.RAG_SNIPPETS,
-        document_id=2,
-    )
-    assert doc.context == context_str
-
-
 def test_gold_standard_annotation_creation_from_dict() -> None:
     """Test creating a gold standard annotation from dictionary data."""
     # This mimics how annotations are created from JSON data

--- a/tests/unit/test_documents.py
+++ b/tests/unit/test_documents.py
@@ -523,7 +523,7 @@ def test_document_creation_minimal():
     )
     assert doc.name == "Minimal Document"
     assert doc.context is None
-    assert doc.context_type == ContextType.EMPTY
+    assert doc.context_type is None
     assert doc.document_id is None
     assert doc.is_final is False
     assert doc.is_linked is False
@@ -656,7 +656,7 @@ def test_document_is_final_requires_good_context_type():
             name="Test Document",
             citation=citation,
             context="some context",
-            context_type=ContextType.EMPTY,
+            context_type=None,
             is_final=True,
             document_identity=DocumentIdentity(
                 doi="10.1000/test",

--- a/tests/unit/test_llm_data_extractor.py
+++ b/tests/unit/test_llm_data_extractor.py
@@ -302,17 +302,6 @@ def test_call_llm_truncates_to_empty_when_system_and_attributes_exceed_max(
     assert user_content["context"] == ""
 
 
-def test_prepare_context_not_implemented(
-    llm_extractor: LLMDataExtractor,
-    sample_eppi_document,
-):
-    """Test that RAG and CUSTOM context types raise NotImplementedError."""
-    payload = "This is the full text."
-    llm_extractor.config.default_context_type = ContextType.RAG_SNIPPETS
-    with pytest.raises(NotImplementedError):
-        llm_extractor._prepare_context(payload=payload)
-
-
 def test_generate_user_message_json(llm_extractor, sample_eppi_attributes):
     """Test the generation of the structured JSON user message."""
     context = "Sample context"


### PR DESCRIPTION
# Pull Request

## Description

User feedback pointed out some inconsistencies and points of unclarity in the documentation (both help messages and in docs).

This PR addresses each of the points in #296, commit-by-commit. It would make sense to review commit-wise.

All changes touch only documentation, except for the removal of unimplemented ContextTypes (or ContextTypes we don't want users to select). This is because the wizard for populating DataExtractionConfig uses the enum to present users with choices.

A less drastic way to achieve this would probably be to make only some of these selectable, possibly by subclassing ContextType with only those that we want users to be able to success (full text or abstract), and using this subclass to type context_type in DataExtractionConfig. However it made sense to me to remove those that we intend to implement but haven't yet, and mark them with TODO. Happy to try this if preferable.

## Related Issue(s)
Closes #296 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement/modification to existing feature
- [x] Documentation update
- [ ] Other (please describe):

## Pre-Review Checklist

Before requesting review, I confirm that:

- [x] All existing and new tests pass locally and in CI
- [x] Core functionality still works locally (e.g. all pipeline scripts)
- [x] Code passes `ruff` linting
- [x] Code passes `mypy` type checking
- [x] Changes are well-documented both in the code (docstrings) and the repo (e.g. readme.md if applicable)
- [x] I have self-reviewed my code (especially if AI-assisted elements are in here). This means no unnecessary comments, refactoring overly verbose AI code, etc. etc.
- [x] PR is pointing to the `development` branch (or appropriate feature branch) rather than `main` branch.

## Testing
Documentation changes only. Edited tests that check that specific unimplemented context types that were present in the enum raised an error.

## Additional Notes


---
**Please review [CONTRIBUTING.md](../CONTRIBUTING.md) for full contribution guidelines.**
