### PR TITLE
feat(experiments): persist run metadata (cost, tokens) to output dir

### DIFF
--- a/deet/data_models/project.py
+++ b/deet/data_models/project.py
@@ -254,3 +254,8 @@ class ExperimentArtefacts:
     def llm_annotation_csv(self) -> Path:
         """Return location of csv containing llm extractions."""
         return self.base_dir / "llm_annotations.csv"
+
+    @property
+    def run_metadata(self) -> Path:
+        """Return location of json capturing run metadata (cost, tokens, model)."""
+        return self.base_dir / "run_metadata.json"

--- a/deet/extractors/cli_helpers.py
+++ b/deet/extractors/cli_helpers.py
@@ -210,4 +210,10 @@ def run_extraction_pipeline(
         encoding="utf-8",
     )
 
+    experiment_artefacts.run_metadata.write_text(
+        run_output.metadata.model_dump_json(indent=2),
+        encoding="utf-8",
+    )
+    logger.info(f"Run metadata saved to: {experiment_artefacts.run_metadata}")
+
     return run_output, processed_annotation_data, experiment_artefacts

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -334,6 +334,7 @@ def test_extract_happy_path(tmp_path):
         mock_extractor.config = fake_config
         mock_run_output = MagicMock()
         mock_run_output.annotated_documents = mock_processed_data.annotated_documents
+        mock_run_output.metadata.model_dump_json.return_value = "{}"
         mock_extractor.extract_from_documents.return_value = mock_run_output
 
         mock_evaluator = mock_evaluator_cls.return_value

--- a/tests/unit/test_cli_helpers.py
+++ b/tests/unit/test_cli_helpers.py
@@ -1,15 +1,18 @@
 """Tests for deet/extractors/cli_helpers.py."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml  # type:ignore[import-untyped]
 
 from deet.data_models.documents import ContextType, Document
+from deet.data_models.extraction import ExtractionRunMetadata, ExtractionRunOutput
 from deet.extractors.cli_helpers import (
     init_extraction_run,
     load_config_from_typer_context,
     prepare_documents,
+    run_extraction_pipeline,
 )
 from deet.extractors.llm_data_extractor import DataExtractionConfig
 
@@ -135,6 +138,61 @@ def test_init_extraction_run(tmp_path):
     mock_logger.add.assert_called_once()
     log_path = mock_logger.add.call_args[0][0]
     assert log_path == experiment_artefacts.base_dir / "deet.log"
+
+
+def test_run_extraction_pipeline_writes_run_metadata(tmp_path, config):
+    """run_extraction_pipeline should persist run metadata (cost/tokens) to disk."""
+    exp_dir = tmp_path / "experiments"
+
+    mock_project = MagicMock()
+    mock_project.experiments_dir = exp_dir
+    mock_project.pdf_dir = tmp_path / "pdfs"
+
+    mock_processed_data = MagicMock()
+    mock_processed_data.attributes = [1]
+    mock_processed_data.documents = []
+    mock_project.process_data.return_value = mock_processed_data
+
+    mock_typer_context = MagicMock()
+    mock_typer_context.obj.project = mock_project
+
+    run_metadata = ExtractionRunMetadata(
+        model="gpt-4o-mini",
+        total_input_tokens=100,
+        total_output_tokens=50,
+        total_cost_usd=0.0123,
+        per_document_tokens={"doc-1": {"input_tokens": 100, "output_tokens": 50}},
+    )
+    run_output = ExtractionRunOutput(annotated_documents=[], metadata=run_metadata)
+
+    with (
+        patch(
+            "deet.extractors.cli_helpers.load_config_from_typer_context",
+            return_value=config,
+        ),
+        patch("deet.extractors.cli_helpers.LLMDataExtractor") as mock_extractor_cls,
+        patch("deet.extractors.cli_helpers.prepare_documents", return_value=[]),
+    ):
+        mock_extractor = mock_extractor_cls.return_value
+        mock_extractor.config = config
+        mock_extractor.extract_from_documents.return_value = run_output
+
+        result_output, _, experiment_artefacts = run_extraction_pipeline(
+            typer_context=mock_typer_context,
+            prompt_population=None,
+        )
+
+    assert result_output is run_output
+
+    metadata_path = experiment_artefacts.run_metadata
+    assert metadata_path.name == "run_metadata.json"
+    assert metadata_path.exists()
+
+    written = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert written["model"] == "gpt-4o-mini"
+    assert written["total_input_tokens"] == 100
+    assert written["total_output_tokens"] == 50
+    assert written["total_cost_usd"] == 0.0123
 
 
 def test_prepare_documents_context_type_abstract(mock_documents, config, tmp_path):


### PR DESCRIPTION
Closes #306. 

The deet experiment output directory now stores the cost of each experiment run as a dedicated, discoverable artefact. The run cost/token data was already computed (ExtractionRunMetadata) but was only buried inside llm_annotations.json. This change writes it to its own run_metadata.json alongside the other output files, giving us a clean place for cost and future run-level metadata.

Changes
**ExperimentArtefacts (deet/data_models/project.py):** added a run_metadata property → run_metadata.json.

**run_extraction_pipeline (deet/extractors/cli_helpers.py):** writes run_output.metadata to run_metadata.json 
after extraction. Applies to both experiments evaluate and experiments predict, since both go through this function.

**Tests:** added a test asserting run_metadata.json is created with the expected model/token/cost fields, and updated the existing extract happy-path test mock.

New output file looks like this: 

```
{
  "model": "azure/gpt-4o-mini",
  "total_input_tokens": 50973,
  "total_output_tokens": 1114,
  "total_cost_usd": 0.009146,
  "per_document_tokens": {
    "126730555": {
      "input_tokens": 15714,
      "output_tokens": 320
    },
    "126730554": {
      "input_tokens": 17475,
      "output_tokens": 448
    },
    "126730556": {
      "input_tokens": 17784,
      "output_tokens": 346
    }
  },
  "timestamp": "2026-06-22T12:35:05.864139Z"
}
```