### PR TITLE
Fix/99 dynamic llm response schema

### DIFF
--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -94,6 +94,19 @@ class AttributeType(StrEnum):
         }
         return mapping[self]
 
+    def llm_annotation_response_model(self) -> type[BaseModel]:
+        """
+        Return the shared Pydantic sub-model for LLM responses of this type.
+
+        One model is built and cached per :class:`AttributeType`; attributes
+        with the same type reuse it in :func:`build_llm_response_model`.
+
+        Returns
+            A Pydantic model class with typed ``output_data`` for this type.
+
+        """
+        return _llm_annotation_response_model_for_type(self)
+
     def to_json_type(self) -> JsonValue:
         """Map AttributeType to JS types for the JSON schema."""
         mapping: JsonDict = {
@@ -425,13 +438,14 @@ class LLMAnnotationResponse(BaseModel):
     """
     LLM response model for a single attribute's annotation.
 
-    Used as the base for the per-attribute sub-models produced by
-    :func:`build_llm_response_model`. The attribute identity is *not* stored on
-    this model; it is encoded in the parent field name (``attribute_<id>``) so
-    the LLM is never asked to repeat (and potentially mismatch) the id.
+    Used as the base for the per-type sub-models produced by
+    :meth:`AttributeType.llm_annotation_response_model`. The attribute identity
+    is *not* stored on this model; it is encoded in the parent field name
+    (``attribute_<id>``) so the LLM is never asked to repeat (and potentially
+    mismatch) the id.
 
     ``output_data`` is typed ``Any`` here and is always overridden with the
-    attribute's concrete Python type when the dynamic sub-model is built.
+    attribute's concrete Python type when the per-type sub-model is built.
     """
 
     output_data: Any = Field(
@@ -454,6 +468,39 @@ class LLMAnnotationResponse(BaseModel):
     # are not included as they're EPPI-specific metadata the LLM cannot provide
 
     model_config = ConfigDict(extra="forbid")
+
+
+_llm_annotation_response_models: dict[AttributeType, type[BaseModel]] = {}
+
+
+def _llm_annotation_response_model_for_type(
+    attribute_type: AttributeType,
+) -> type[BaseModel]:
+    """
+    Build or return the cached LLM annotation sub-model for an attribute type.
+
+    Args:
+        attribute_type: The attribute data type to model.
+
+    Returns:
+        A Pydantic model class with ``output_data`` typed for ``attribute_type``.
+
+    """
+    cached = _llm_annotation_response_models.get(attribute_type)
+    if cached is not None:
+        return cached
+
+    output_type = attribute_type.to_python_type()
+    model = create_model(
+        f"LLM{attribute_type.name}AnnotationResponse",
+        __base__=LLMAnnotationResponse,
+        output_data=(
+            output_type,
+            Field(..., description="The LLM's annotation for this attribute."),
+        ),
+    )
+    _llm_annotation_response_models[attribute_type] = model
+    return model
 
 
 class _DynamicLLMResponseBase(BaseModel):
@@ -530,17 +577,8 @@ def build_llm_response_model(attributes: list[Attribute]) -> type[BaseModel]:
 
     response_fields: dict[str, tuple[type[BaseModel], Any]] = {}
     for attribute in attributes:
-        output_type = attribute.output_data_type.to_python_type()
-        attribute_model = create_model(
-            f"Attribute{attribute.attribute_id}Response",
-            __base__=LLMAnnotationResponse,
-            output_data=(
-                output_type,
-                Field(..., description="The LLM's annotation for this attribute."),
-            ),
-        )
         response_fields[attribute_response_key(attribute.attribute_id)] = (
-            attribute_model,
+            attribute.output_data_type.llm_annotation_response_model(),
             Field(..., description=attribute.attribute_label),
         )
 

--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -4,7 +4,7 @@ import csv
 from collections.abc import Callable
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import Any, Literal, Never, TypeVar
+from typing import Any, Literal, Never, TypeVar, cast
 
 from loguru import logger
 from pydantic import (
@@ -456,6 +456,12 @@ class LLMAnnotationResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class _DynamicLLMResponseBase(BaseModel):
+    """Base for dynamically generated LLM response models."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
 ATTRIBUTE_RESPONSE_KEY_PREFIX = "attribute_"
 
 
@@ -540,6 +546,6 @@ def build_llm_response_model(attributes: list[Attribute]) -> type[BaseModel]:
 
     return create_model(
         "DynamicLLMResponse",
-        __config__=ConfigDict(extra="forbid"),
-        **response_fields,
+        __base__=_DynamicLLMResponseBase,
+        **cast(Any, response_fields),
     )

--- a/deet/data_models/base.py
+++ b/deet/data_models/base.py
@@ -4,10 +4,17 @@ import csv
 from collections.abc import Callable
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import Any, Literal, Never, TypeVar, cast
+from typing import Any, Literal, Never, TypeVar
 
 from loguru import logger
-from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    create_model,
+    model_validator,
+)
 from pydantic.config import JsonDict, JsonValue
 from tabulate import tabulate
 
@@ -416,27 +423,20 @@ class LLMInputSchema(BaseModel):
 
 class LLMAnnotationResponse(BaseModel):
     """
-    LLM response model for a single annotation.
+    LLM response model for a single attribute's annotation.
 
-    This mirrors EppiGoldStandardAnnotation structure but uses attribute_id
-    instead of full EppiAttribute object, as the LLM cannot provide the full
-    attribute object.
+    Used as the base for the per-attribute sub-models produced by
+    :func:`build_llm_response_model`. The attribute identity is *not* stored on
+    this model; it is encoded in the parent field name (``attribute_<id>``) so
+    the LLM is never asked to repeat (and potentially mismatch) the id.
+
+    ``output_data`` is typed ``Any`` here and is always overridden with the
+    attribute's concrete Python type when the dynamic sub-model is built.
     """
 
-    attribute_id: int = Field(
-        ..., description="The ID of the EPPI attribute being annotated"
-    )
     output_data: Any = Field(
         ...,
-        description="The LLM's annotation.",
-        json_schema_extra=cast(
-            "JsonDict",
-            {
-                "anyOf": [
-                    attribute_type.to_json_type() for attribute_type in AttributeType
-                ]
-            },
-        ),
+        description="The LLM's annotation for this attribute.",
     )
     additional_text: str | None = Field(
         ...,
@@ -456,16 +456,90 @@ class LLMAnnotationResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class LLMResponseSchema(BaseModel):
-    """
-    Root schema for LLM annotation extraction response.
+ATTRIBUTE_RESPONSE_KEY_PREFIX = "attribute_"
 
-    This structure matches the expected format that can be converted
-    to list[GoldStandardAnnotation] after attribute resolution.
-    """
 
-    annotations: list[LLMAnnotationResponse] = Field(
-        ..., description="List of annotations extracted from the document"
+def attribute_response_key(attribute_id: int) -> str:
+    """
+    Build the dynamic-model field name used for a given attribute.
+
+    Args:
+        attribute_id: The attribute's unique identifier.
+
+    Returns:
+        The field name, e.g. ``"attribute_1234"``.
+
+    """
+    return f"{ATTRIBUTE_RESPONSE_KEY_PREFIX}{attribute_id}"
+
+
+def attribute_id_from_response_key(key: str) -> int:
+    """
+    Recover the attribute id from a dynamic-model field name.
+
+    Args:
+        key: A field name such as ``"attribute_1234"``.
+
+    Returns:
+        The integer attribute id encoded in the key.
+
+    Raises:
+        ValueError: If ``key`` does not encode a valid integer attribute id.
+
+    """
+    raw_id = key.removeprefix(ATTRIBUTE_RESPONSE_KEY_PREFIX)
+    try:
+        return int(raw_id)
+    except ValueError as exc:
+        msg = f"Cannot recover attribute id from response key {key!r}"
+        raise ValueError(msg) from exc
+
+
+def build_llm_response_model(attributes: list[Attribute]) -> type[BaseModel]:
+    """
+    Build a dynamic LLM response model from the selected attributes.
+
+    Each attribute becomes a required, correctly typed sub-model keyed by
+    ``attribute_<id>`` on the returned root model. Because every key is required
+    and ``extra="forbid"`` is set at every level, the JSON schema forces the LLM
+    to return exactly one response per attribute - no missing attributes, no
+    extra/hallucinated attributes, and ``output_data`` constrained to the
+    attribute's concrete type. This also yields a schema that providers such as
+    Ollama accept as valid (unlike an ``Any``-typed field).
+
+    Args:
+        attributes: The attributes to extract; must be non-empty.
+
+    Returns:
+        A dynamically created Pydantic model class suitable for use as a
+        structured-output schema and for validating the LLM response.
+
+    Raises:
+        ValueError: If ``attributes`` is empty.
+
+    """
+    if not attributes:
+        msg = "Cannot build an LLM response model from an empty attribute list"
+        raise ValueError(msg)
+
+    response_fields: dict[str, tuple[type[BaseModel], Any]] = {}
+    for attribute in attributes:
+        output_type = attribute.output_data_type.to_python_type()
+        attribute_model = create_model(
+            f"Attribute{attribute.attribute_id}Response",
+            __base__=LLMAnnotationResponse,
+            output_data=(
+                output_type,
+                Field(..., description="The LLM's annotation for this attribute."),
+            ),
+        )
+        response_fields[attribute_response_key(attribute.attribute_id)] = (
+            attribute_model,
+            Field(..., description=attribute.attribute_label),
+        )
+
+    return create_model(
+        "DynamicLLMResponse",
+        __config__=ConfigDict(extra="forbid"),
+        **response_fields,
     )
-
-    model_config = ConfigDict(extra="forbid")

--- a/deet/extractors/llm_data_extractor.py
+++ b/deet/extractors/llm_data_extractor.py
@@ -790,8 +790,11 @@ class LLMDataExtractor:
             attribute_id = attribute_id_from_response_key(field_name)
             attribute = attributes_by_id.get(attribute_id)
             if attribute is None:
-                logger.warning(f"No attribute found for ID: {attribute_id}")
-                continue
+                msg = (
+                    f"No attribute found for ID: {attribute_id}. "
+                    "The dynamic response model and attribute list are out of sync."
+                )
+                raise ValueError(msg)
 
             attribute_response = getattr(validated_response, field_name)
             additional_text = (

--- a/deet/extractors/llm_data_extractor.py
+++ b/deet/extractors/llm_data_extractor.py
@@ -22,7 +22,8 @@ from deet.data_models.base import (
     Attribute,
     GoldStandardAnnotation,
     LLMInputSchema,
-    LLMResponseSchema,
+    attribute_id_from_response_key,
+    build_llm_response_model,
 )
 from deet.data_models.documents import (
     ContextType,
@@ -133,9 +134,7 @@ class DataExtractionConfig(BaseModel):
 
     max_context_tokens: Annotated[
         int | None,
-        UI(
-            help=("Maximum input context length " "(Leave blank for provider default).")
-        ),
+        UI(help=("Maximum input context length (Leave blank for provider default).")),
     ] = Field(
         default=None,
         description=(
@@ -335,11 +334,16 @@ class LLMDataExtractor:
         prompt = self._generate_user_message_json(
             payload=context, attributes=selected_attributes
         )
+        # Build a response schema specific to the selected attributes so the LLM
+        # must return exactly one correctly typed response per attribute.
+        response_model = build_llm_response_model(selected_attributes)
         llm_response, messages, output_tokens, input_tokens = self._call_llm(
-            prompt=prompt
+            prompt=prompt, response_model=response_model
         )
         annotations = self._parse_llm_response(
-            response_content=llm_response, attributes=selected_attributes
+            response_content=llm_response,
+            response_model=response_model,
+            attributes=selected_attributes,
         )
 
         return DocumentExtractionResult(
@@ -663,12 +667,19 @@ class LLMDataExtractor:
             )
             raise ValueError(msg) from e
 
-    def _call_llm(self, prompt: str) -> tuple[str, list[dict[str, Any]], int, int]:
+    def _call_llm(
+        self,
+        prompt: str,
+        response_model: type[BaseModel],
+    ) -> tuple[str, list[dict[str, Any]], int, int]:
         """
         Call the LLM with the given prompt.
 
         Args:
             prompt: The user prompt (with context and attributes).
+            response_model: Dynamic Pydantic model describing the expected
+                response; its JSON schema is passed as the structured-output
+                schema so the LLM must return one typed entry per attribute.
 
         Returns:
             Tuple of (LLM response text, messages list, output token count,
@@ -697,8 +708,7 @@ class LLMDataExtractor:
         )
         if prompt_cost is not None:
             logger.info(
-                f"Estimated input cost: ${prompt_cost:.6f} USD "
-                f"({input_tokens} tokens)"
+                f"Estimated input cost: ${prompt_cost:.6f} USD ({input_tokens} tokens)"
             )
 
         response = litellm.completion(
@@ -711,7 +721,7 @@ class LLMDataExtractor:
                 "type": "json_schema",
                 "json_schema": {
                     "name": "llm_annotation_response",
-                    "schema": LLMResponseSchema.model_json_schema(),
+                    "schema": response_model.model_json_schema(),
                     "strict": True,
                 },
             },
@@ -734,25 +744,33 @@ class LLMDataExtractor:
     def _parse_llm_response(
         self,
         response_content: str,
+        response_model: type[BaseModel],
         attributes: list[Attribute],
     ) -> list[GoldStandardAnnotation]:
         """
-        Parse and validate LLM response against GoldStandardAnnotation structure.
+        Parse and validate LLM response against the dynamic response schema.
+
+        The response is validated against ``response_model`` (built from the
+        selected attributes), which guarantees one correctly typed entry per
+        attribute. Each ``attribute_<id>`` field is then mapped back to its
+        full Attribute and converted to a GoldStandardAnnotation.
 
         Args:
-            response_content: Raw JSON string response from LLM
-            attributes: List of attributes to match against
+            response_content: Raw JSON string response from LLM.
+            response_model: Dynamic model the response was requested against.
+            attributes: List of attributes to resolve ids against.
 
         Returns:
-            List of GoldStandardAnnotation objects
+            List of GoldStandardAnnotation objects.
 
         Raises:
-            ValidationError: If response fails schema validation.
+            ValidationError: If response fails schema validation (e.g. a missing
+                attribute, an extra attribute, or a mistyped ``output_data``).
             ValueError: If JSON parsing fails.
 
         """
         try:
-            validated_response = LLMResponseSchema.model_validate_json(response_content)
+            validated_response = response_model.model_validate_json(response_content)
         except ValidationError as ve:
             logger.error(f"LLM response failed schema validation: {ve}")
             logger.debug(f"Response content: {response_content}")
@@ -762,40 +780,32 @@ class LLMDataExtractor:
             logger.error(f"Failed to parse LLM response as JSON: {je}")
             raise ValueError(error_msg) from je
 
+        attributes_by_id = {attr.attribute_id: attr for attr in attributes}
         annotations = []
         logger.debug(
-            f"Parsing LLM response with {len(validated_response.annotations)} "
-            f"annotations"
+            f"Parsing LLM response with {len(response_model.model_fields)} "
+            f"attribute responses"
         )
-        for llm_annotation in validated_response.annotations:
-            # Resolve attribute_id to full Attribute
-            attribute = next(
-                (
-                    attr
-                    for attr in attributes
-                    if attr.attribute_id == llm_annotation.attribute_id
-                ),
-                None,
-            )
-
-            if not attribute:
-                logger.warning(
-                    f"No attribute found for ID: {llm_annotation.attribute_id}"
-                )
+        for field_name in response_model.model_fields:
+            attribute_id = attribute_id_from_response_key(field_name)
+            attribute = attributes_by_id.get(attribute_id)
+            if attribute is None:
+                logger.warning(f"No attribute found for ID: {attribute_id}")
                 continue
 
+            attribute_response = getattr(validated_response, field_name)
             additional_text = (
-                llm_annotation.additional_text
+                attribute_response.additional_text
                 if self.config.include_additional_text
                 else None
             )
             reasoning = (
-                llm_annotation.reasoning if self.config.include_reasoning else None
+                attribute_response.reasoning if self.config.include_reasoning else None
             )
             # Convert to full EppiGoldStandardAnnotation
             annotation = GoldStandardAnnotation(
                 attribute=attribute,
-                raw_data=llm_annotation.output_data,
+                raw_data=attribute_response.output_data,
                 annotation_type=AnnotationType.LLM,
                 additional_text=additional_text,
                 reasoning=reasoning,
@@ -803,7 +813,7 @@ class LLMDataExtractor:
             annotations.append(annotation)
             logger.debug(
                 f"Created annotation for attribute {attribute.attribute_id}: "
-                f"output_data={llm_annotation.output_data}"
+                f"output_data={attribute_response.output_data}"
             )
 
         logger.debug(f"Successfully parsed {len(annotations)} annotations")

--- a/deet/prompts/system_prompt.txt
+++ b/deet/prompts/system_prompt.txt
@@ -1,5 +1,5 @@
-You will be provided with a context from a paper and a list of questions below.
-Based on the context, answer each question as true or false and return a list of JSON objects.
+You will be provided with a context from a paper and a list of attributes (questions) below.
+Based on the context, answer every attribute and return a single JSON object containing one response per attribute. Each attribute response is keyed by its attribute id in the form "attribute_<id>" and must contain the output_data, additional_text and reasoning fields. You must provide a response for every attribute and must not invent attributes that were not asked for.
 
 Please explain step by step reasoning behind each answer.
 You should also cite text from the paper context to support your answer if the answer is True. If the citation is present at multiple places, please cite all of them in the additional_text key. You can separate the citations with ------.

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -15,8 +15,6 @@ from deet.data_models.base import (
     AttributeType,
     GoldStandardAnnotation,
     LLMInputSchema,
-    attribute_id_from_response_key,
-    attribute_response_key,
     build_llm_response_model,
     coerce_annotation_to_list,
 )
@@ -959,24 +957,6 @@ def test_llm_input_schema_ignores_extra_fields() -> None:
 
 
 # dynamic LLM response schema (issue #99)
-def test_attribute_response_key_roundtrip() -> None:
-    """Key construction and id recovery are inverse operations."""
-    assert attribute_response_key(1234) == "attribute_1234"
-    assert attribute_id_from_response_key("attribute_1234") == 1234
-
-
-def test_attribute_id_from_response_key_invalid_raises() -> None:
-    """A key that does not encode an integer id raises ValueError."""
-    with pytest.raises(ValueError, match="Cannot recover attribute id"):
-        attribute_id_from_response_key("attribute_not_an_int")
-
-
-def test_build_llm_response_model_empty_attributes_raises() -> None:
-    """Building a model from no attributes is an error."""
-    with pytest.raises(ValueError, match="empty attribute list"):
-        build_llm_response_model([])
-
-
 def test_build_llm_response_model_requires_every_attribute() -> None:
     """Each selected attribute becomes a required, typed top-level key."""
     attributes = [

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -998,6 +998,29 @@ def test_build_llm_response_model_requires_every_attribute() -> None:
     assert parsed["attribute_2345"]["output_data"] == 120
 
 
+def test_build_llm_response_model_reuses_schema_per_attribute_type() -> None:
+    """Attributes with the same type share one cached sub-model class."""
+    attributes = [
+        Attribute(
+            prompt="Has intervention?",
+            output_data_type=AttributeType.BOOL,
+            attribute_id=1234,
+            attribute_label="Has intervention",
+        ),
+        Attribute(
+            prompt="Is relevant?",
+            output_data_type=AttributeType.BOOL,
+            attribute_id=5678,
+            attribute_label="Is relevant",
+        ),
+    ]
+    model = build_llm_response_model(attributes)
+
+    bool_submodel = AttributeType.BOOL.llm_annotation_response_model()
+    assert model.model_fields["attribute_1234"].annotation is bool_submodel
+    assert model.model_fields["attribute_5678"].annotation is bool_submodel
+
+
 def test_build_llm_response_model_enforces_output_data_type() -> None:
     """output_data is constrained to the attribute's declared type."""
     attributes = [

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1013,8 +1013,9 @@ def test_build_llm_response_model_requires_every_attribute() -> None:
             },
         }
     )
-    assert valid.attribute_1234.output_data is True
-    assert valid.attribute_2345.output_data == 120
+    parsed = valid.model_dump()
+    assert parsed["attribute_1234"]["output_data"] is True
+    assert parsed["attribute_2345"]["output_data"] == 120
 
 
 def test_build_llm_response_model_enforces_output_data_type() -> None:

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 from destiny_sdk.references import ReferenceFileInput
+from pydantic import ValidationError
 
 from deet.data_models.base import (
     SUPPORTED_TYPES,
@@ -14,6 +15,9 @@ from deet.data_models.base import (
     AttributeType,
     GoldStandardAnnotation,
     LLMInputSchema,
+    attribute_id_from_response_key,
+    attribute_response_key,
+    build_llm_response_model,
     coerce_annotation_to_list,
 )
 from deet.data_models.documents import (
@@ -952,3 +956,115 @@ def test_llm_input_schema_ignores_extra_fields() -> None:
     schema = LLMInputSchema.model_validate(data)
     assert schema.prompt == "Test prompt"
     assert not hasattr(schema, "extra_field")
+
+
+# dynamic LLM response schema (issue #99)
+def test_attribute_response_key_roundtrip() -> None:
+    """Key construction and id recovery are inverse operations."""
+    assert attribute_response_key(1234) == "attribute_1234"
+    assert attribute_id_from_response_key("attribute_1234") == 1234
+
+
+def test_attribute_id_from_response_key_invalid_raises() -> None:
+    """A key that does not encode an integer id raises ValueError."""
+    with pytest.raises(ValueError, match="Cannot recover attribute id"):
+        attribute_id_from_response_key("attribute_not_an_int")
+
+
+def test_build_llm_response_model_empty_attributes_raises() -> None:
+    """Building a model from no attributes is an error."""
+    with pytest.raises(ValueError, match="empty attribute list"):
+        build_llm_response_model([])
+
+
+def test_build_llm_response_model_requires_every_attribute() -> None:
+    """Each selected attribute becomes a required, typed top-level key."""
+    attributes = [
+        Attribute(
+            prompt="Has intervention?",
+            output_data_type=AttributeType.BOOL,
+            attribute_id=1234,
+            attribute_label="Has intervention",
+        ),
+        Attribute(
+            prompt="Sample size?",
+            output_data_type=AttributeType.INTEGER,
+            attribute_id=2345,
+            attribute_label="Sample size",
+        ),
+    ]
+    model = build_llm_response_model(attributes)
+
+    schema = model.model_json_schema()
+    assert set(schema["required"]) == {"attribute_1234", "attribute_2345"}
+    assert schema["additionalProperties"] is False
+
+    valid = model.model_validate(
+        {
+            "attribute_1234": {
+                "output_data": True,
+                "additional_text": None,
+                "reasoning": None,
+            },
+            "attribute_2345": {
+                "output_data": 120,
+                "additional_text": "120 participants.",
+                "reasoning": "Stated directly.",
+            },
+        }
+    )
+    assert valid.attribute_1234.output_data is True
+    assert valid.attribute_2345.output_data == 120
+
+
+def test_build_llm_response_model_enforces_output_data_type() -> None:
+    """output_data is constrained to the attribute's declared type."""
+    attributes = [
+        Attribute(
+            prompt="Sample size?",
+            output_data_type=AttributeType.INTEGER,
+            attribute_id=2345,
+            attribute_label="Sample size",
+        ),
+    ]
+    model = build_llm_response_model(attributes)
+
+    with pytest.raises(ValidationError):
+        model.model_validate(
+            {
+                "attribute_2345": {
+                    "output_data": "not an int",
+                    "additional_text": None,
+                    "reasoning": None,
+                }
+            }
+        )
+
+
+def test_build_llm_response_model_forbids_extra_attributes() -> None:
+    """Unexpected top-level attributes are rejected."""
+    attributes = [
+        Attribute(
+            prompt="Has intervention?",
+            output_data_type=AttributeType.BOOL,
+            attribute_id=1234,
+            attribute_label="Has intervention",
+        ),
+    ]
+    model = build_llm_response_model(attributes)
+
+    with pytest.raises(ValidationError):
+        model.model_validate(
+            {
+                "attribute_1234": {
+                    "output_data": True,
+                    "additional_text": None,
+                    "reasoning": None,
+                },
+                "attribute_9999": {
+                    "output_data": False,
+                    "additional_text": None,
+                    "reasoning": None,
+                },
+            }
+        )

--- a/tests/unit/test_llm_data_extractor.py
+++ b/tests/unit/test_llm_data_extractor.py
@@ -9,7 +9,12 @@ import pytest
 from loguru import logger
 from pydantic import ValidationError
 
-from deet.data_models.base import AnnotationType, GoldStandardAnnotation, LLMInputSchema
+from deet.data_models.base import (
+    AnnotationType,
+    GoldStandardAnnotation,
+    LLMInputSchema,
+    build_llm_response_model,
+)
 from deet.data_models.documents import ContextType
 from deet.data_models.eppi import (
     AttributeType,
@@ -112,14 +117,16 @@ def mock_litellm_completion():
     """Fixture to mock the litellm.completion call."""
     with patch("litellm.completion") as mock_completion:
         response_content = {
-            "annotations": [
-                {
-                    "attribute_id": 1234,
-                    "output_data": True,
-                    "reasoning": "Found in text.",
-                    "additional_text": "Citation here.",
-                }
-            ]
+            "attribute_1234": {
+                "output_data": True,
+                "reasoning": "Found in text.",
+                "additional_text": "Citation here.",
+            },
+            "attribute_2345": {
+                "output_data": False,
+                "reasoning": "Not found in text.",
+                "additional_text": "No citation.",
+            },
         }
         mock_response = MagicMock()
         mock_response.choices[0].message.content = json.dumps(response_content)
@@ -264,8 +271,9 @@ def test_call_llm_raises_when_payload_exceeds_max_by_default(
     )
     llm_extractor.config.max_context_tokens = 1000
     llm_extractor.config.truncate_on_overflow = False
+    response_model = build_llm_response_model(sample_eppi_attributes)
     with pytest.raises(ValueError, match="exceeds max_context_tokens"):
-        llm_extractor._call_llm(prompt=prompt)
+        llm_extractor._call_llm(prompt=prompt, response_model=response_model)
 
 
 def test_call_llm_truncates_when_truncate_on_overflow_enabled(
@@ -279,7 +287,8 @@ def test_call_llm_truncates_when_truncate_on_overflow_enabled(
     )
     llm_extractor.config.max_context_tokens = 1000
     llm_extractor.config.truncate_on_overflow = True
-    llm_extractor._call_llm(prompt=prompt)
+    response_model = build_llm_response_model(sample_eppi_attributes)
+    llm_extractor._call_llm(prompt=prompt, response_model=response_model)
     call_args = mock_litellm_completion.call_args
     user_content = json.loads(call_args.kwargs["messages"][1]["content"])
     assert len(user_content["context"]) < len(long_context)
@@ -296,7 +305,8 @@ def test_call_llm_truncates_to_empty_when_system_and_attributes_exceed_max(
     )
     llm_extractor.config.max_context_tokens = 5
     llm_extractor.config.truncate_on_overflow = True
-    llm_extractor._call_llm(prompt=prompt)
+    response_model = build_llm_response_model(sample_eppi_attributes)
+    llm_extractor._call_llm(prompt=prompt, response_model=response_model)
     call_args = mock_litellm_completion.call_args
     user_content = json.loads(call_args.kwargs["messages"][1]["content"])
     assert user_content["context"] == ""
@@ -339,10 +349,13 @@ def test_generate_user_message_json(llm_extractor, sample_eppi_attributes):
 
 
 @pytest.mark.parametrize("llm_provider", [*list(LLMProvider), "unsupported_provider"])
-def test_call_llm(mock_litellm_completion, mock_settings, llm_provider):
+def test_call_llm(
+    mock_litellm_completion, mock_settings, llm_provider, sample_eppi_attributes
+):
     """Test the _call_llm method."""
     prompt = '{"key": "value"}'
     mock_settings.llm_provider = llm_provider
+    response_model = build_llm_response_model(sample_eppi_attributes)
 
     if llm_provider in [member.value for member in LLMProvider]:
         config = DataExtractionConfig(
@@ -351,7 +364,7 @@ def test_call_llm(mock_litellm_completion, mock_settings, llm_provider):
 
         llm_extractor = create_llm_extractor(config, mock_settings)
         response, messages, output_tokens, input_tokens = llm_extractor._call_llm(
-            prompt
+            prompt, response_model=response_model
         )
 
         mock_litellm_completion.assert_called_once()
@@ -382,32 +395,54 @@ def test_call_llm(mock_litellm_completion, mock_settings, llm_provider):
 def test_parse_llm_response(
     llm_extractor, sample_eppi_attributes, sample_eppi_document
 ):
-    """Test successful parsing of a valid LLM response."""
+    """Test successful parsing of a valid keyed LLM response."""
+    response_model = build_llm_response_model(sample_eppi_attributes)
     response_content = json.dumps(
         {
-            "annotations": [
-                {
-                    "attribute_id": 1234,
-                    "output_data": True,
-                    "reasoning": "Found.",
-                    "additional_text": "Citation.",
-                }
-            ]
+            "attribute_1234": {
+                "output_data": True,
+                "reasoning": "Found.",
+                "additional_text": "Citation.",
+            },
+            "attribute_2345": {
+                "output_data": False,
+                "reasoning": "Not found.",
+                "additional_text": "No citation.",
+            },
         }
     )
     annotations = llm_extractor._parse_llm_response(
-        response_content, sample_eppi_attributes
+        response_content, response_model, sample_eppi_attributes
     )
-    # it filters through ids which exist in both,
-    # so even though the length of sample_eppi_attributes is
-    # longer than response_content,
-    # below is expeceted behaviour and we're happy.
-    assert len(annotations) == 1
-    annotation = annotations[0]
-    assert isinstance(annotation, GoldStandardAnnotation)
-    assert annotation.attribute.attribute_id == 1234
-    assert annotation.output_data is True
-    assert annotation.annotation_type == AnnotationType.LLM
+    # The dynamic schema requires a response for every selected attribute.
+    assert len(annotations) == 2
+    by_id = {a.attribute.attribute_id: a for a in annotations}
+    assert all(isinstance(a, GoldStandardAnnotation) for a in annotations)
+    assert by_id[1234].output_data is True
+    assert by_id[2345].output_data is False
+    assert by_id[1234].annotation_type == AnnotationType.LLM
+
+
+def test_parse_llm_response_missing_attribute_raises(
+    llm_extractor,
+    sample_eppi_attributes,
+):
+    """A response omitting a required attribute must fail validation."""
+    response_model = build_llm_response_model(sample_eppi_attributes)
+    # Only one of the two required attributes is present.
+    incomplete_response = json.dumps(
+        {
+            "attribute_1234": {
+                "output_data": True,
+                "reasoning": "Found.",
+                "additional_text": "Citation.",
+            }
+        }
+    )
+    with pytest.raises(ValidationError):
+        llm_extractor._parse_llm_response(
+            incomplete_response, response_model, sample_eppi_attributes
+        )
 
 
 def test_parse_llm_response_validation_error(
@@ -415,11 +450,17 @@ def test_parse_llm_response_validation_error(
     sample_eppi_attributes,
 ):
     """Test that _parse_llm_response raises ValidationError for bad schema."""
+    response_model = build_llm_response_model(sample_eppi_attributes)
     invalid_response = json.dumps(
-        {"annotations": [{"attribute_id": "attr1"}]}
-    )  # Missing fields
+        {
+            "attribute_1234": {"output_data": True},
+            "attribute_2345": {"output_data": False},
+        }
+    )  # Missing additional_text/reasoning fields
     with pytest.raises(ValidationError):
-        llm_extractor._parse_llm_response(invalid_response, sample_eppi_attributes)
+        llm_extractor._parse_llm_response(
+            invalid_response, response_model, sample_eppi_attributes
+        )
 
 
 def test_parse_llm_response_json_decode_error(
@@ -427,9 +468,12 @@ def test_parse_llm_response_json_decode_error(
     sample_eppi_attributes,
 ):
     """Test that _parse_llm_response raises ValueError for invalid JSON."""
+    response_model = build_llm_response_model(sample_eppi_attributes)
     invalid_json = "this is not json"
     with pytest.raises(ValueError, match="Invalid JSON"):
-        llm_extractor._parse_llm_response(invalid_json, sample_eppi_attributes)
+        llm_extractor._parse_llm_response(
+            invalid_json, response_model, sample_eppi_attributes
+        )
 
 
 def test_extract_from_document(
@@ -446,14 +490,15 @@ def test_extract_from_document(
         context_type=ContextType.FULL_DOCUMENT,
     )
     assert isinstance(result, DocumentExtractionResult)
-    assert len(result.annotations) == 1
+    # The dynamic schema requires a response for every selected attribute.
+    assert len(result.annotations) == 2
     assert isinstance(result.messages, list)
     assert len(result.messages) >= 1
     assert result.output_tokens == 42
     assert result.input_tokens == 100
     assert result.model is not None
     assert result.timestamp is not None
-    assert result.annotations[0].attribute.attribute_id == 1234
+    assert {a.attribute.attribute_id for a in result.annotations} == {1234, 2345}
     mock_litellm_completion.assert_called_once()
 
 

--- a/tests/unit/test_llm_data_extractor.py
+++ b/tests/unit/test_llm_data_extractor.py
@@ -445,6 +445,33 @@ def test_parse_llm_response_missing_attribute_raises(
         )
 
 
+def test_parse_llm_response_attribute_lookup_mismatch_raises(
+    llm_extractor,
+    sample_eppi_attributes,
+):
+    """A validated model field with no matching attribute must raise."""
+    response_model = build_llm_response_model(sample_eppi_attributes)
+    valid_response = json.dumps(
+        {
+            "attribute_1234": {
+                "output_data": True,
+                "reasoning": "Found.",
+                "additional_text": "Citation.",
+            },
+            "attribute_2345": {
+                "output_data": False,
+                "reasoning": "Not found.",
+                "additional_text": "No citation.",
+            },
+        }
+    )
+    mismatched_attributes = [sample_eppi_attributes[0]]
+    with pytest.raises(ValueError, match="No attribute found for ID: 2345"):
+        llm_extractor._parse_llm_response(
+            valid_response, response_model, mismatched_attributes
+        )
+
+
 def test_parse_llm_response_validation_error(
     llm_extractor,
     sample_eppi_attributes,


### PR DESCRIPTION
## Summary
- Replace loose `LLMResponseSchema` (`output_data: Any`, list of annotations) with a dynamically generated per-attribute Pydantic model keyed by `attribute_<id>`.
- Enforce `extra="forbid"` and typed `output_data` so the LLM must return exactly one correctly typed response per requested attribute.
- Update system prompt, extractor parsing, and unit tests.

## Test plan
- [x] `pytest tests/unit/test_base.py tests/unit/test_llm_data_extractor.py` — 106 passed
- [x] `ruff` + `mypy` + pre-commit hooks pass
- [x] Manual CLI A/B on PIK_HIC (5 attributes, gemma3:1b):
  - `development`: 1–2/5 attributes returned, mixed bool/string types, hallucinated attribute id 6
  - `fix/99`: 5/5 attributes every doc, all bool, no hallucinations

Closes #99